### PR TITLE
Feature-Bug-1041-Dataset download name, clone dataset service list changes

### DIFF
--- a/tdei-ui/src/components/VerticalStepper/VerticalStepper.js
+++ b/tdei-ui/src/components/VerticalStepper/VerticalStepper.js
@@ -222,7 +222,7 @@ export default function VerticalStepper({ stepsData, onStepsComplete,currentStep
   };
   // Validation function for the first step (ServiceUpload)
   const validateServiceUpload = () => {
-    if (selectedData[activeStep] != null) {
+    if(selectedData[activeStep].tdei_service_id !== null && selectedData[activeStep].tdei_service_id !== ""){
       return true
     }
     return false;

--- a/tdei-ui/src/routes/CloneDataset/CloneDatasetStepper.js
+++ b/tdei-ui/src/routes/CloneDataset/CloneDatasetStepper.js
@@ -118,7 +118,7 @@ export default function CloneDatasetStepper({ stepsData, onStepsComplete, curren
                 "dataset_area": "",
                 "collection_method": "",
                 "data_source": "",
-                "schema_version": "",
+                "schema_version": dataset.metadata.dataset_detail.schema_version ?? "",
                 "collected_by": ""
             },
             "data_provenance": {
@@ -338,7 +338,7 @@ export default function CloneDatasetStepper({ stepsData, onStepsComplete, curren
   const componentProps = {
     selectedData: selectedData[activeStep],
     ...(activeStep === 0
-      ? { onSelectedServiceChange: handleSelectedDataChange }
+      ? { onSelectedServiceChange: handleSelectedDataChange, dataset, fromCloneDataset: true }
       : { onSelectedFileChange: handleSelectedDataChange }),
   };
 

--- a/tdei-ui/src/routes/CloneDataset/CloneDatasetStepper.js
+++ b/tdei-ui/src/routes/CloneDataset/CloneDatasetStepper.js
@@ -18,7 +18,7 @@ import style from "../../components/VerticalStepper/steps.module.css";
 // Custom Icon component for service upload
 export const ServiceIcon = () => (
   <Icon sx={{ alignItems: "center", display: "flex" }}>
-    <img src={serviceUpload} height={20} width={20} color='white' style={{ width: "100%", height: "70%" }} />
+    <img src={serviceUpload} height={20} alt='service-icon' width={20} color='white' style={{ width: "100%", height: "70%" }} />
   </Icon>
 );
 
@@ -102,8 +102,8 @@ export default function CloneDatasetStepper({ stepsData, onStepsComplete, curren
       setSelectedData(prevData => ({
         ...prevData,
         0: {
-          tdei_project_group_id: dataset.project_group.tdei_project_group_id,
-          tdei_service_id: dataset.service.tdei_service_id,
+          tdei_project_group_id: "",
+          tdei_service_id: "",
           service_type: dataset.data_type
         },
         1:{
@@ -178,6 +178,7 @@ export default function CloneDatasetStepper({ stepsData, onStepsComplete, curren
       return;
     }
     handleBackUntil();
+    // eslint-disable-next-line
   }, [currentStep]);
 
   // Function to update selected data
@@ -295,7 +296,7 @@ export default function CloneDatasetStepper({ stepsData, onStepsComplete, curren
   };
 
   // Validation function for the first step (ServiceUpload)
-  const validateServiceUpload = () => selectedData[activeStep] != null;
+  const validateServiceUpload = () => selectedData[activeStep].tdei_service_id !== null && selectedData[activeStep].tdei_service_id !== "";
 
   // Validation function for the third step (Metadata)
   const validateMetadata = () => {

--- a/tdei-ui/src/routes/Datasets/DatasetsActions.js
+++ b/tdei-ui/src/routes/Datasets/DatasetsActions.js
@@ -38,7 +38,7 @@ const DatasetsActions = ({ status, onAction, isReleasedDataset }) => {
           <Dropdown.Item disabled={isReleasedDataset} eventKey="editMetadata" className={style.itemRow}>
             <img src={editImage} className={style.itemIcon} alt="" />Edit Metadata
           </Dropdown.Item>
-          <Dropdown.Item disabled={!isDataGenerator} eventKey="cloneDataset" className={style.itemRow}>
+          <Dropdown.Item disabled={!isDataGenerator && !user.isAdmin} eventKey="cloneDataset" className={style.itemRow}>
             <img src={cloneImg} className={style.itemIcon} alt="" />Clone Dataset
           </Dropdown.Item>
           <Dropdown.Item eventKey="downLoadDataset" className={style.itemRow}>

--- a/tdei-ui/src/routes/Datasets/DatasetsActions.js
+++ b/tdei-ui/src/routes/Datasets/DatasetsActions.js
@@ -10,10 +10,12 @@ import cloneImg from "../../assets/img/clone-img.svg";
 import editImage from "../../assets/img/edit-img.svg";
 import { useAuth } from "../../hooks/useAuth";
 import downloadDatasetImg from "../../assets/img/download-img.svg";
+import useIsDatasetsAccessible from '../../hooks/useIsDatasetsAccessible';
 
 const DatasetsActions = ({ status, onAction, isReleasedDataset }) => {
   const isPocUser = useIsPoc();
   const { user } = useAuth();
+  const isDataGenerator = useIsDatasetsAccessible();
   
   const canDeactivate = isPocUser || user?.isAdmin;
 
@@ -36,7 +38,7 @@ const DatasetsActions = ({ status, onAction, isReleasedDataset }) => {
           <Dropdown.Item disabled={isReleasedDataset} eventKey="editMetadata" className={style.itemRow}>
             <img src={editImage} className={style.itemIcon} alt="" />Edit Metadata
           </Dropdown.Item>
-          <Dropdown.Item disabled={isReleasedDataset} eventKey="cloneDataset" className={style.itemRow}>
+          <Dropdown.Item disabled={!isDataGenerator} eventKey="cloneDataset" className={style.itemRow}>
             <img src={cloneImg} className={style.itemIcon} alt="" />Clone Dataset
           </Dropdown.Item>
           <Dropdown.Item eventKey="downLoadDataset" className={style.itemRow}>

--- a/tdei-ui/src/routes/UploadDataset/ServiceUpload.js
+++ b/tdei-ui/src/routes/UploadDataset/ServiceUpload.js
@@ -1,7 +1,6 @@
-import React from 'react';
-import style from "./../Services/Services.module.css"
-import Typography from '@mui/material/Typography';
-import { Button, Form, Spinner, Col, Row } from "react-bootstrap";
+import React, { useState, useEffect } from 'react';
+import style from "./../Services/Services.module.css";
+import { Button, Form, Spinner } from "react-bootstrap";
 import { useAuth } from "../../hooks/useAuth";
 import { debounce } from "lodash";
 import useGetServices from "../../hooks/service/useGetServices";
@@ -11,14 +10,13 @@ import iconNoData from "./../../assets/img/icon-noData.svg";
 import Select from 'react-select';
 import ServicesList from './ServicesList';
 
-// Functional component for Service Upload
-const ServiceUpload = ({ selectedData, onSelectedServiceChange }) => {
+const ServiceUpload = ({ selectedData, onSelectedServiceChange, dataset, fromCloneDataset }) => {
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const [, setQuery] = React.useState("");
-  const [debounceQuery, setDebounceQuery] = React.useState("");
-  const [serviceType, setServiceType] = React.useState("");
-  const [selectedService, setSelectedService] = React.useState({});
+  const [, setQuery] = useState("");
+  const [debounceQuery, setDebounceQuery] = useState("");
+  const [serviceType, setServiceType] = useState(fromCloneDataset ? dataset.data_type : "");
+  const [selectedService, setSelectedService] = useState({});
 
   // Fetching services data using custom hook
   const {
@@ -30,12 +28,6 @@ const ServiceUpload = ({ selectedData, onSelectedServiceChange }) => {
     isLoading,
   } = useGetServices(debounceQuery, user?.isAdmin, serviceType);
 
-  // Event handler for selecting service type from dropdown
-  const handleSelect = (value) => {
-    
-    queryClient.invalidateQueries({ queryKey: [GET_SERVICES] });
-    setServiceType(value.value);
-  };
   // Event handler for selecting a service
   const handleSelectedService = (list) => {
   setSelectedService(list);
@@ -82,22 +74,30 @@ const ServiceUpload = ({ selectedData, onSelectedServiceChange }) => {
                 }}
               />
             </div>
-            <div className="d-flex align-items-center">
-              <div>Type</div>
-              <div className={style.selectServiceFilter}>
-                <Select
-                  isSearchable={false}
-                  defaultValue={{ label: "All", value: "" }}
-                  onChange={handleSelect}
-                  options={options}
-                  components={{
-                    IndicatorSeparator: () => null
-                  }}
-                  styles={{ container: (provided) => ({ ...provided, width: '80%' }) }}
-                />
+            {!fromCloneDataset && (
+              <div className="d-flex align-items-center">
+                <div>Type</div>
+                <div className={style.selectServiceFilter}>
+                  <Select
+                    isSearchable={false}
+                    defaultValue={{ label: "All", value: "" }}
+                    onChange={(value) => {
+                      queryClient.invalidateQueries({ queryKey: [GET_SERVICES] });
+                      setServiceType(value.value);
+                    }}
+                    options={[
+                      { value: 'flex', label: 'Flex' },
+                      { value: 'pathways', label: 'Pathways' },
+                      { value: 'osw', label: 'Osw' },
+                    ]}
+                    components={{
+                      IndicatorSeparator: () => null
+                    }}
+                    styles={{ container: (provided) => ({ ...provided, width: '80%' }) }}
+                  />
+                </div>
               </div>
-            </div>
-            
+            )}
           </div>
 
           {data?.pages?.map((values, i) => (
@@ -109,7 +109,7 @@ const ServiceUpload = ({ selectedData, onSelectedServiceChange }) => {
                     className={style.noDataIcon}
                     alt="no-data-icon"
                   />
-                  <div className={style.noDataText}>No service found..!</div>
+                  <div className={style.noDataText}>No services found. Please try changing project group!</div>
                 </div>
               ) : null}
               {values?.data?.map((list) => (
@@ -124,7 +124,7 @@ const ServiceUpload = ({ selectedData, onSelectedServiceChange }) => {
               ))}
             </React.Fragment>
           ))}
-          {isError ? " Error loading project group list" : null}
+          {isError ? " Error loading services list" : null}
           {isLoading ? (
             <div className="d-flex justify-content-center">
               <Spinner size="md" />

--- a/tdei-ui/src/routes/UploadDataset/ServiceUpload.js
+++ b/tdei-ui/src/routes/UploadDataset/ServiceUpload.js
@@ -17,6 +17,7 @@ const ServiceUpload = ({ selectedData, onSelectedServiceChange, dataset, fromClo
   const [debounceQuery, setDebounceQuery] = useState("");
   const [serviceType, setServiceType] = useState(fromCloneDataset ? dataset.data_type : "");
   const [selectedService, setSelectedService] = useState({});
+  const [previousProjectGroupId, setPreviousProjectGroupId] = useState( selectedData && selectedData.tdei_project_group_id ? selectedData.tdei_project_group_id :"");
 
   // Fetching services data using custom hook
   const {
@@ -28,15 +29,38 @@ const ServiceUpload = ({ selectedData, onSelectedServiceChange, dataset, fromClo
     isLoading,
   } = useGetServices(debounceQuery, user?.isAdmin, serviceType);
 
+  // Effect to reset selected service if project group ID changes
+  useEffect(() => {
+    if (Array.isArray(data.pages) && data.pages.length > 0) {
+      const firstPageData = data.pages[0]?.data ?? [];
+      const newProjectGroupId = firstPageData.length > 0 ? firstPageData[0]?.tdei_project_group_id : "";
+      if (newProjectGroupId !== previousProjectGroupId) {
+          setSelectedService({
+            tdei_project_group_id: "",
+            tdei_service_id: "",
+            service_type: ""
+          });
+          setPreviousProjectGroupId(newProjectGroupId);
+          onSelectedServiceChange({
+            tdei_project_group_id: "",
+            tdei_service_id: "",
+            service_type: ""
+          });
+        }
+      }
+  }, [data]);
+
   // Event handler for selecting a service
   const handleSelectedService = (list) => {
-  setSelectedService(list);
-  onSelectedServiceChange({
-    tdei_project_group_id: list.tdei_project_group_id,
-    tdei_service_id: list.tdei_service_id,
-    service_type: list.service_type
-  });
+    setPreviousProjectGroupId(list.tdei_project_group_id);
+    setSelectedService(list);
+    onSelectedServiceChange({
+      tdei_project_group_id: list.tdei_project_group_id,
+      tdei_service_id: list.tdei_service_id,
+      service_type: list.service_type
+    });
   };
+
   // Event handler for searching services
   const handleSearch = (e) => {
     setDebounceQuery(e.target.value);
@@ -85,11 +109,7 @@ const ServiceUpload = ({ selectedData, onSelectedServiceChange, dataset, fromClo
                       queryClient.invalidateQueries({ queryKey: [GET_SERVICES] });
                       setServiceType(value.value);
                     }}
-                    options={[
-                      { value: 'flex', label: 'Flex' },
-                      { value: 'pathways', label: 'Pathways' },
-                      { value: 'osw', label: 'Osw' },
-                    ]}
+                    options={options}
                     components={{
                       IndicatorSeparator: () => null
                     }}

--- a/tdei-ui/src/services/apiServices.js
+++ b/tdei-ui/src/services/apiServices.js
@@ -496,7 +496,7 @@ export async function downloadDataset(data) {
     const urlBlob = window.URL.createObjectURL(new Blob([response.data]));
     const a = document.createElement('a');
     a.href = urlBlob;
-    a.download = 'response.zip';
+    a.download = `${data.tdei_dataset_id}.zip`;
     document.body.appendChild(a);
     a.click();
     a.remove();


### PR DESCRIPTION
Fixed the bug -> https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1041 : 
* Dataset id as download file name.
* Clone -> All released datasets -> enable for data generators, poc, admin.
* Services for clone only existing dataset’s service type should be displayed.
* Service id reset when project group is reset.
* Pre-populate schema version for clone dataset.

Screenshots: 
<img width="1470" alt="Screenshot 2024-06-19 at 2 41 13 PM" src="https://github.com/TaskarCenterAtUW/TDEI-user-management-front-end/assets/142565248/69db80ff-8ee7-45a6-b7f0-10aae65ffefe">
<img width="1470" alt="Screenshot 2024-06-19 at 2 42 01 PM" src="https://github.com/TaskarCenterAtUW/TDEI-user-management-front-end/assets/142565248/b3a73a4f-ebd6-4d57-b88f-05ff1739b2d5">
<img width="1470" alt="Screenshot 2024-06-19 at 2 42 38 PM" src="https://github.com/TaskarCenterAtUW/TDEI-user-management-front-end/assets/142565248/27caef92-b9af-40b1-b040-eb57cdd7203f">
<img width="1470" alt="Screenshot 2024-06-19 at 2 43 18 PM" src="https://github.com/TaskarCenterAtUW/TDEI-user-management-front-end/assets/142565248/bc13003a-c5d2-4b6f-9c96-b9834f50d51d">
<img width="1470" alt="Screenshot 2024-06-19 at 2 43 39 PM" src="https://github.com/TaskarCenterAtUW/TDEI-user-management-front-end/assets/142565248/624e7a02-c08e-4923-8ea0-67d203734913">
<img width="1470" alt="Screenshot 2024-06-19 at 2 43 54 PM" src="https://github.com/TaskarCenterAtUW/TDEI-user-management-front-end/assets/142565248/6edd53d0-825e-4c12-903c-324ce3fe6cfa">

