### PR TITLE
Feature Bug- 1102: Frontend 'show' filter with 'submitted by me' and 'all'

### DIFF
--- a/tdei-ui/src/hooks/jobs/useGetJobDetails.js
+++ b/tdei-ui/src/hooks/jobs/useGetJobDetails.js
@@ -9,10 +9,6 @@ function useGetJobDetails(isAdmin, job_id = "", enabled = false) {
     const { tdei_project_group_id } = useSelector(getSelectedProjectGroup);
     const [refreshKey, setRefreshKey] = useState(0); // for refreshing data
 
-    useEffect(() => {
-        console.log("useGetJobDetails Hook called with job_id:", job_id);
-    }, [job_id]);
-
     const { data, error, isLoading, refetch } = useQuery(
         [GET_JOB_DETAILS, tdei_project_group_id, job_id, isAdmin, refreshKey],
         () => getJobDetails(tdei_project_group_id, job_id, isAdmin),

--- a/tdei-ui/src/hooks/jobs/useGetJobs.js
+++ b/tdei-ui/src/hooks/jobs/useGetJobs.js
@@ -5,20 +5,23 @@ import { getJobs } from "../../services";
 import { GET_JOBS } from "../../utils";
 import { useState, useEffect } from "react";
 
-function useGetJobs(isAdmin,job_id = "", job_type = "", status = "") {
+function useGetJobs(isAdmin, job_id = "", job_type = "", status = "", show = "") {
     const { tdei_project_group_id } = useSelector(getSelectedProjectGroup);
-    const [refreshKey, setRefreshKey] = useState(0); // for refeshing data
+    const [refreshKey, setRefreshKey] = useState(0); // for refreshing data
+
     const { data, isError, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery(
-        [GET_JOBS, tdei_project_group_id, job_id, job_type, status, refreshKey],
-        ({ queryKey, pageParam }) =>
-            getJobs(queryKey[1], pageParam, isAdmin, queryKey[2], queryKey[3], queryKey[4]),
+        [GET_JOBS, tdei_project_group_id, job_id, job_type, status, show, refreshKey],
+        ({ queryKey, pageParam = 1 }) => {
+            return getJobs(queryKey[1], pageParam, isAdmin, queryKey[2], queryKey[3], queryKey[4], queryKey[5]);
+        },
         {
             getNextPageParam: (lastPage) => {
                 return lastPage.data.length > 0 && lastPage.data.length === 10
                     ? lastPage.pageParam + 1
                     : undefined;
             },
-            keepPreviousData : false
+            keepPreviousData: false,
+            refetchOnWindowFocus: false,
         }
     );
 
@@ -26,9 +29,6 @@ function useGetJobs(isAdmin,job_id = "", job_type = "", status = "") {
     const refreshData = () => {
         setRefreshKey((prevKey) => prevKey + 1);
     };
-    useEffect(() => {
-        refreshData();
-    }, [job_id, status, job_type]);
     return { data, isError, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading, refreshData };
 }
 

--- a/tdei-ui/src/hooks/service/useGetDatasets.js
+++ b/tdei-ui/src/hooks/service/useGetDatasets.js
@@ -24,9 +24,6 @@ function useGetDatasets(searchText = "", status = "All", dataType) {
   const refreshData = () => {
     setRefreshKey((prevKey) => prevKey + 1);
   };
-  useEffect(() => {
-    refreshData();
-  }, [searchText, status, dataType]);
   return { data, isError, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading, refreshData };
 }
 

--- a/tdei-ui/src/hooks/service/useGetReleaseDatasets.js
+++ b/tdei-ui/src/hooks/service/useGetReleaseDatasets.js
@@ -24,9 +24,6 @@ function useGetReleasedDatasets(searchText = "", dataType) {
   const refreshData = () => {
     setRefreshKey((prevKey) => prevKey + 1);
   };
-  useEffect(() => {
-    refreshData();
-  }, [searchText, dataType]);
   return { data, isError, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading, refreshData };
 }
 

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -41,7 +41,6 @@ const MyDatasets = () => {
     }, [data]);
 
     const handleSelectedDataType = (value) => {
-        queryClient.invalidateQueries({ queryKey: [GET_DATASETS] });
         setDataType(value.value);
     };
 

--- a/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
+++ b/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
@@ -47,7 +47,6 @@ const ReleasedDatasets = () => {
   }, [data]);
   // Event handler for selecting data type from dropdown
   const handleSelectedDataType = (value) => {
-    queryClient.invalidateQueries({ queryKey: [GET_DATASETS] });
     setDataType(value.value);
   };
 
@@ -93,7 +92,7 @@ const ReleasedDatasets = () => {
       setSortedData(sorted);
     } else if (eventKey === 'asc') {
       // Sort by name in ascending order
-      const sorted = [...sortedData].sort((a, b) => a.name.localeCompare(b.name));
+      const sorted = [...sortedData].sort((a, b) => a.metadata?.dataset_detail?.name.localeCompare(b.metadata?.dataset_detail?.name));
       setSortedData(sorted);
     }
   };

--- a/tdei-ui/src/routes/Jobs/Jobs.js
+++ b/tdei-ui/src/routes/Jobs/Jobs.js
@@ -50,7 +50,7 @@ const Jobs = () => {
     ];
 
     const jobShowOptions = [
-        { value: '', label: 'All' },
+        { value: 'all', label: 'All' },
         { value: 'me', label: 'Submitted by me' }
     ]
 
@@ -66,7 +66,7 @@ const Jobs = () => {
         isFetchingNextPage,
         isLoading,
         refreshData
-    } = useGetJobs(user.isAdmin, debounceQuery, jobType.value, jobStatus.value);
+    } = useGetJobs(user.isAdmin, debounceQuery, jobType.value, jobStatus.value,jobShow.value);
 
     useEffect(() => {
         // Check if data is available and update sortedData
@@ -78,12 +78,10 @@ const Jobs = () => {
 
     const handleJobTypeSelect = (value) => {
         setJobType(value);
-        queryClient.invalidateQueries({ queryKey: [GET_JOBS] });
     };
 
     const handleJobStatusSelect = (value) => {
         setJobStatus(value);
-        queryClient.invalidateQueries({ queryKey: [GET_JOBS] });
     };
 
     const handleJobShowSelect = (value) => {
@@ -112,7 +110,7 @@ const Jobs = () => {
             setSortedData(sorted);
         } else if (eventKey === 'type') {
             // Sort by type in ascending order
-            const sorted = [...sortedData].sort((a, b) => a.data_type.localeCompare(b.data_type));
+            const sorted = [...sortedData].sort((a, b) => a.jobType.localeCompare(b.jobType));
             setSortedData(sorted);
         } else if (eventKey === 'asc') {
             // Sort by name in ascending order

--- a/tdei-ui/src/services/apiServices.js
+++ b/tdei-ui/src/services/apiServices.js
@@ -153,18 +153,19 @@ export async function getService(tdei_service_id, service_type, tdei_project_gro
     pageParam,
   };
 }
-export async function getJobs(tdei_project_group_id, pageParam = 1, isAdmin, job_id, job_type, status) {
+export async function getJobs(tdei_project_group_id, pageParam = 1, isAdmin, job_id, job_type, status,job_show) {
 
   const params = {
     page_no: pageParam,
     page_size: 10,
   };
 
-  // if (isAdmin) {
-  //   params.tdei_project_group_id = null;
-  // } else {
-  //   params.tdei_project_group_id = tdei_project_group_id;
-  // }
+  if(!isAdmin) {
+    params.tdei_project_group_id = tdei_project_group_id;
+  }
+  if(job_show == "all"){
+    params.show_group_jobs = true;
+  }
 
   if (job_type) {
     params.job_type = job_type;


### PR DESCRIPTION
- Added functionality to the filter to display all/submitted by me jobs.
- Fixed the issue: jobs and dataset listing page make 2 duplicate calls for listing.

Test Case Verified for bug 1102: 

1. **Submitted by me** only displays the ones created by the logged in user.
2. **All** displays all the jobs belonging to that project group.
- Tested with 2 users belonging to the same project group: 
   -- A can see all jobs belonging to that project group in jobs list with filter **All**. Which implies, A can also see B's jobs in jobs list with filter **All**.
   -- A can see only A's jobs list with filter **Submitted by me**.
   -- Vice versa.
   
 User A of project group Asian Leisure Pvt Ltd with filter **Submitted by me**: 
<img width="1470" alt="Screenshot 2024-07-17 at 12 11 32 PM" src="https://github.com/user-attachments/assets/3d435da5-3e62-419b-ae36-04180759b7a6">
 User A of project group Asian Leisure Pvt Ltd with filter **All**: 
<img width="1470" alt="Screenshot 2024-07-17 at 12 11 38 PM" src="https://github.com/user-attachments/assets/96eeb312-30b7-46d8-921a-e379c301b00c">
 User B of project group Asian Leisure Pvt Ltd with filter **All**: 
<img width="1470" alt="Screenshot 2024-07-17 at 12 12 07 PM" src="https://github.com/user-attachments/assets/67f9690c-b8ec-49de-8c1b-e264dd50cba9">
 User B of project group Asian Leisure Pvt Ltd with filter **Submitted by me**: 
<img width="1470" alt="Screenshot 2024-07-17 at 12 12 17 PM" src="https://github.com/user-attachments/assets/2f4ca6c5-6baf-490a-9edf-a8eadd3b9ae3">
