### PR TITLE
Feature-Bug-1193-Unable to view create job page although the user is data generator

### DIFF
--- a/tdei-ui/src/routes/Jobs/CreateJob.js
+++ b/tdei-ui/src/routes/Jobs/CreateJob.js
@@ -588,7 +588,7 @@ const CreateJobService = () => {
 
 
     return (
-        <Layout>
+        <div className={style.createJobLayout}>
             <div className={` ${jobType ? style.createJobContainer : style.createJobContainerWithJobType}`}>
                 <>
                     <div className={style.createJobTitle}>Create New Job</div>
@@ -703,7 +703,7 @@ const CreateJobService = () => {
                     )}
                 </>
             </div>
-        </Layout>
+        </div>
     );
 };
 

--- a/tdei-ui/src/routes/Jobs/Jobs.module.css
+++ b/tdei-ui/src/routes/Jobs/Jobs.module.css
@@ -505,3 +505,8 @@
 .itemIcon {
   margin-left: 10px;
 }
+.createJobLayout {
+  height: 100%;
+  padding: 20px;
+  background-color: #f8f8f8;
+}


### PR DESCRIPTION
Fixed the bug: https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1193

Fix made: 
- Replaced root component **Layout** which by default checks only if user is poc or admin with <div>
- The parent page **jobs list** already has a check, if ---> **roles.includes("poc") || roles.includes("flex_data_generator") || roles.includes("osw_data_generator") || roles.includes("pathways_data_generator")**

So, by default, any user who is not able to see jobs list also cannot access create job page.


<img width="1470" alt="Screenshot 2024-08-28 at 7 45 51 PM" src="https://github.com/user-attachments/assets/997478c6-a4e5-4ad2-b93b-5a522caf34fe">
<img width="1470" alt="Screenshot 2024-08-28 at 7 46 05 PM" src="https://github.com/user-attachments/assets/b7285a82-d72f-46b0-9775-3a398218326b">

