### PR TITLE
Feature task-1345-1341-OSW convert and download job changes

### DIFF
--- a/tdei-ui/src/components/DownloadModal/DownloadModal.js
+++ b/tdei-ui/src/components/DownloadModal/DownloadModal.js
@@ -12,8 +12,12 @@ const DownloadModal = ({
     setSelectedFormat,
     selectedFileVersion,
     setSelectedFileVersion,
-    isLoading 
+    isLoading
 }) => {
+    // Set default format as 'osw' and file version as 'latest'
+    const defaultFormat = { value: 'osw', label: 'OSW' };
+    const defaultFileVersion = { value: 'latest', label: 'Latest' };
+
     return (
         <Modal show={show} onHide={handleClose}>
             <Modal.Header closeButton={!isLoading}> 
@@ -25,18 +29,20 @@ const DownloadModal = ({
                     <Select
                         options={formatOptions}
                         onChange={(option) => setSelectedFormat(option)}
-                        value={selectedFormat}
+                        value={selectedFormat || defaultFormat}
                         isDisabled={isLoading} 
                     />
+                    <div className="tdei-hint-text">(File format to download. Default to osw.)</div>
                 </Form.Group>
                 <Form.Group className="mt-3">
                     <Form.Label>Select File Version</Form.Label>
                     <Select
                         options={fileVersionOptions}
                         onChange={(option) => setSelectedFileVersion(option)}
-                        value={selectedFileVersion}
+                        value={selectedFileVersion || defaultFileVersion}
                         isDisabled={isLoading} 
                     />
+                     <div className="tdei-hint-text">(The Latest version includes recent modifications; the Original version is the initial upload.)</div>
                 </Form.Group>
             </Modal.Body>
             <Modal.Footer>

--- a/tdei-ui/src/components/DownloadModal/DownloadModal.js
+++ b/tdei-ui/src/components/DownloadModal/DownloadModal.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Modal, Button, Form, Spinner } from 'react-bootstrap';
+import Select from 'react-select';
+
+const DownloadModal = ({
+    show,
+    handleClose,
+    handleDownload,
+    formatOptions,
+    fileVersionOptions,
+    selectedFormat,
+    setSelectedFormat,
+    selectedFileVersion,
+    setSelectedFileVersion,
+    isLoading 
+}) => {
+    return (
+        <Modal show={show} onHide={handleClose}>
+            <Modal.Header closeButton={!isLoading}> 
+                <Modal.Title>OSW Dataset Download</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Form.Group>
+                    <Form.Label>Select Format</Form.Label>
+                    <Select
+                        options={formatOptions}
+                        onChange={(option) => setSelectedFormat(option)}
+                        value={selectedFormat}
+                        isDisabled={isLoading} 
+                    />
+                </Form.Group>
+                <Form.Group className="mt-3">
+                    <Form.Label>Select File Version</Form.Label>
+                    <Select
+                        options={fileVersionOptions}
+                        onChange={(option) => setSelectedFileVersion(option)}
+                        value={selectedFileVersion}
+                        isDisabled={isLoading} 
+                    />
+                </Form.Group>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    variant="outline-secondary"
+                    className="tdei-secondary-button"
+                    onClick={handleClose}
+                    disabled={isLoading} 
+                >
+                    Cancel
+                </Button>
+                <Button
+                    variant="primary"
+                    className="tdei-primary-button"
+                    onClick={handleDownload}
+                    disabled={isLoading} 
+                >
+                    {isLoading ? <Spinner size="sm" /> : "Download"} 
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default DownloadModal;

--- a/tdei-ui/src/components/DropZone/Dropzone.js
+++ b/tdei-ui/src/components/DropZone/Dropzone.js
@@ -24,7 +24,8 @@ function Dropzone({ onDrop, accept, format, selectedFile }) {
             setMyFiles([...acceptedFiles]);
             onDrop(acceptedFiles);
         },
-        maxFiles: 1
+        maxFiles: 1,
+        noClick: accept === ""
     });
     // Function to remove a file from myFiles state
     const removeFile = fileToRemove => () => {

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -133,10 +133,12 @@ const MyDatasets = () => {
         setIsLoadingDownload(false);
         handleToast();
         setShowDownloadModal(false);
+        setSelectedFormat(null);
+        setSelectedFileVersion(null);
     };
 
     const onError = (err) => {
-        const errorMessage = err.data || "An unexpected error occurred";
+        const errorMessage = err.data || showDownloadModal ? "Only latest version of the file can be downloaded" : "An unexpected error occurred";
         console.error("Error message:", errorMessage);
         setOperationResult("error");
         setOpen(true);
@@ -144,6 +146,8 @@ const MyDatasets = () => {
         setShowSuccessModal(false);
         setIsLoadingDownload(false); 
         setShowDownloadModal(false);
+        setSelectedFormat(null);
+        setSelectedFileVersion(null);
     };
 
     const { mutate: publishDataset, isLoading: isPublishing } = usePublishDataset({ onSuccess, onError });
@@ -165,27 +169,20 @@ const MyDatasets = () => {
 
     const handleDownloadDataset = (dataset) => {
         setIsLoadingDownload(true);
-        if (selectedDataset && selectedFormat && selectedFileVersion && selectedDataset.data_type === 'osw') {
+        if (selectedDataset && selectedDataset.data_type === 'osw') {
+            const format = selectedFormat ? selectedFormat.value : 'osw';
+            const fileVersion = selectedFileVersion ? selectedFileVersion.value : 'latest';
             downloadDataset({
                 tdei_dataset_id: selectedDataset.tdei_dataset_id,
                 data_type: selectedDataset.data_type,
-                format: selectedFormat.value,
-                file_version: selectedFileVersion.value
+                format: format,
+                file_version: fileVersion
             });
-            // setShowDownloadModal(false);
-            setSelectedFormat(null);
-            setSelectedFileVersion(null);
         } else {
-            if (selectedDataset && selectedDataset.data_type === 'osw') {
-                downloadDataset({ tdei_dataset_id: selectedDataset.tdei_dataset_id, data_type: selectedDataset.data_type });
-                // setShowDownloadModal(false);
-            } else {
-                downloadDataset({ tdei_dataset_id: dataset.tdei_dataset_id, data_type: dataset.data_type });
-            }
+            downloadDataset({ tdei_dataset_id: dataset.tdei_dataset_id, data_type: dataset.data_type });
         }
         setSelectedDataset(null);
-    };
-
+    };    
     const onAction = (eventKey, dataset) => {
         setSelectedDataset(dataset);
         setEventKey(eventKey);

--- a/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
+++ b/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
@@ -19,23 +19,34 @@ import ClearIcon from '@mui/icons-material/Clear';
 import dayjs from 'dayjs';
 import ProjectAutocomplete from './../../components/ProjectAutocomplete/ProjectAutocomplete';
 import ServiceAutocomplete from '../../components/ServiceAutocomplete/ServiceAutocomplete';
+import DownloadModal from '../../components/DownloadModal/DownloadModal';
+import ResponseToast from '../../components/ToastMessage/ResponseToast';
 
 const ReleasedDatasets = () => {
   const queryClient = useQueryClient();
   const { user } = useAuth();
+  const [isLoadingDownload, setIsLoadingDownload] = useState(false);
   const [query, setQuery] = useState("");
   const [debounceQuery, setDebounceQuery] = useState("");
   const [dataType, setDataType] = useState("");
   const [sortedData, setSortedData] = useState([]);
   const [eventKey, setEventKey] = useState("");
   const navigate = useNavigate();
-  const [projectGroupId, setProjectGroupId] = useState(""); 
+  const [projectGroupId, setProjectGroupId] = useState("");
   const [tdeiServiceId, setTdeiServiceId] = useState("");
   const [sortField, setSortField] = useState('uploaded_timestamp');
   const [sortOrder, setSortOrder] = useState('DESC');
   // Date range state
   const [validFrom, setValidFrom] = useState(null);
   const [validTo, setValidTo] = useState(null);
+  const [selectedDataset, setSelectedDataset] = useState(null);
+  const [showDownloadModal, setShowDownloadModal] = useState(false);
+  const [selectedFormat, setSelectedFormat] = useState(null);
+  const [selectedFileVersion, setSelectedFileVersion] = useState(null);
+  const [open, setOpen] = useState(false);
+  const [operationResult, setOperationResult] = useState("");
+  const [customErrorMessage, setCustomErrorMessage] = useState("");
+
 
   // Options for data type dropdown
   const options = [
@@ -95,9 +106,44 @@ const ReleasedDatasets = () => {
     []
   );
 
-  const { mutate: downloadDataset, isLoading: isDownloadingDataset } = useDownloadDataset();
+  const { mutate: downloadDataset, isLoading: isDownloadingDataset } = useDownloadDataset({
+    onSuccess: () => {
+      setIsLoadingDownload(false);
+      setShowDownloadModal(false);
+      setOperationResult("success");
+      handleToast();
+    },
+    onError: (err) => {
+      console.error("Error downloading dataset:", err);
+      setIsLoadingDownload(false);
+      setShowDownloadModal(false);
+      setOperationResult("error");
+      setCustomErrorMessage(err.data || "Only latest version of the file can be downloaded");
+      handleToast();
+    }
+  });
+
+
   const handleDownloadDataset = (dataset) => {
-    downloadDataset({ tdei_dataset_id: dataset.tdei_dataset_id, data_type: dataset.data_type });
+    setIsLoadingDownload(true);
+    if (selectedDataset && selectedFormat && selectedFileVersion && selectedDataset.data_type === 'osw') {
+      downloadDataset({
+        tdei_dataset_id: selectedDataset.tdei_dataset_id,
+        data_type: selectedDataset.data_type,
+        format: selectedFormat.value,
+        file_version: selectedFileVersion.value
+      });
+      setSelectedFormat(null);
+      setSelectedFileVersion(null);
+    } else if (selectedDataset && selectedDataset.data_type === 'osw') {
+      downloadDataset({
+        tdei_dataset_id: selectedDataset.tdei_dataset_id,
+        data_type: selectedDataset.data_type
+      });
+    } else {
+      downloadDataset({ tdei_dataset_id: dataset.tdei_dataset_id, data_type: dataset.data_type });
+    }
+    setSelectedDataset(null);
   };
   // Event handler for selecting action button on a dataset
   const onInspect = () => { }
@@ -108,8 +154,11 @@ const ReleasedDatasets = () => {
   };
 
   const onAction = (eventKey, dataset) => {
+    setSelectedDataset(dataset);
     setEventKey(eventKey);
-    if (eventKey === 'downLoadDataset') {
+    if (eventKey === 'downLoadDataset' && dataset.data_type === 'osw') {
+      setShowDownloadModal(true);
+    } else if (eventKey === 'downLoadDataset') {
       handleDownloadDataset(dataset);
     } else if (eventKey === 'cloneDataset') {
       navigate('/CloneDataset', { state: { dataset } });
@@ -125,17 +174,44 @@ const ReleasedDatasets = () => {
     setSortOrder(order);
     refreshData();
   }
+  const formatOptions = [
+    { value: 'osm', label: 'OSM' },
+    { value: 'osw', label: 'OSW' }
+  ];
+
+  const fileVersionOptions = [
+    { value: 'latest', label: 'Latest' },
+    { value: 'original', label: 'Original' }
+  ];
+
+  const handleToast = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+  const getToastMessage = () => {
+    switch (eventKey) {
+      case 'downLoadDataset':
+        return operationResult === "success"
+          ? "Success! Download has been initiated."
+          : customErrorMessage;
+      default:
+        return "";
+    }
+  };
 
   // Callback to handle project group selection from ProjectAutocomplete
   const handleProjectGroupSelect = useCallback((selectedId) => {
     setProjectGroupId(selectedId || "");
-    refreshData(); 
+    refreshData();
   }, [refreshData]);
 
   // Callback to handle service selection from ServiceAutocomplete
   const handleServiceSelect = useCallback((serviceId) => {
     setTdeiServiceId(serviceId || "");
-    refreshData(); 
+    refreshData();
   }, [refreshData]);
 
   return (
@@ -185,9 +261,9 @@ const ReleasedDatasets = () => {
           </Col>
           <Col md={4} className="mb-2">
             <Form.Group>
-            <ServiceAutocomplete
+              <ServiceAutocomplete
                 onSelectService={handleServiceSelect}
-                isAdmin={true} 
+                isAdmin={true}
               />
             </Form.Group>
           </Col>
@@ -262,6 +338,31 @@ const ReleasedDatasets = () => {
             Load More {isFetchingNextPage && <Spinner size="sm" />}
           </Button>
         )}
+        <DownloadModal
+          show={showDownloadModal}
+          handleClose={() => {
+            if (!isLoadingDownload) {
+              setShowDownloadModal(false);
+              setSelectedFormat(null);
+              setSelectedFileVersion(null);
+              setSelectedDataset(null);
+            }
+          }}
+          handleDownload={handleDownloadDataset}
+          formatOptions={formatOptions}
+          fileVersionOptions={fileVersionOptions}
+          selectedFormat={selectedFormat}
+          setSelectedFormat={setSelectedFormat}
+          selectedFileVersion={selectedFileVersion}
+          setSelectedFileVersion={setSelectedFileVersion}
+          isLoading={isLoadingDownload}
+        />
+        <ResponseToast
+          showtoast={open}
+          handleClose={handleClose}
+          type={operationResult === "success" ? "success" : "error"}
+          message={getToastMessage()}
+        />
       </Form>
     </div>
   );

--- a/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
+++ b/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
@@ -112,39 +112,40 @@ const ReleasedDatasets = () => {
       setShowDownloadModal(false);
       setOperationResult("success");
       handleToast();
+      setSelectedFormat(null);
+      setSelectedFileVersion(null);
     },
     onError: (err) => {
       console.error("Error downloading dataset:", err);
       setIsLoadingDownload(false);
       setShowDownloadModal(false);
       setOperationResult("error");
-      setCustomErrorMessage(err.data || "Only latest version of the file can be downloaded");
+      setCustomErrorMessage(err.data || showDownloadModal ? "Only latest version of the file can be downloaded": 'An unexpected error occurred');
       handleToast();
+      setSelectedFormat(null);
+      setSelectedFileVersion(null);
     }
   });
 
 
   const handleDownloadDataset = (dataset) => {
     setIsLoadingDownload(true);
-    if (selectedDataset && selectedFormat && selectedFileVersion && selectedDataset.data_type === 'osw') {
-      downloadDataset({
-        tdei_dataset_id: selectedDataset.tdei_dataset_id,
-        data_type: selectedDataset.data_type,
-        format: selectedFormat.value,
-        file_version: selectedFileVersion.value
-      });
-      setSelectedFormat(null);
-      setSelectedFileVersion(null);
-    } else if (selectedDataset && selectedDataset.data_type === 'osw') {
-      downloadDataset({
-        tdei_dataset_id: selectedDataset.tdei_dataset_id,
-        data_type: selectedDataset.data_type
-      });
+    if (selectedDataset && selectedDataset.data_type === 'osw') {
+        // Set default format as 'osw' and version as 'latest' if not selected
+        const format = selectedFormat ? selectedFormat.value : 'osw';
+        const fileVersion = selectedFileVersion ? selectedFileVersion.value : 'latest';
+
+        downloadDataset({
+            tdei_dataset_id: selectedDataset.tdei_dataset_id,
+            data_type: selectedDataset.data_type,
+            format: format,
+            file_version: fileVersion
+        });
     } else {
-      downloadDataset({ tdei_dataset_id: dataset.tdei_dataset_id, data_type: dataset.data_type });
+        downloadDataset({ tdei_dataset_id: dataset.tdei_dataset_id, data_type: dataset.data_type });
     }
     setSelectedDataset(null);
-  };
+};  
   // Event handler for selecting action button on a dataset
   const onInspect = () => { }
 

--- a/tdei-ui/src/routes/Jobs/CreateJob.js
+++ b/tdei-ui/src/routes/Jobs/CreateJob.js
@@ -480,25 +480,29 @@ const CreateJobService = () => {
                             <Dropzone
                                 onDrop={onDrop}
                                 accept={
-                                    jobType.value === "quality-metric-tag"
-                                        ? { 'application/json': ['.json'] }
-                                        : jobType.value === "osw-convert" && (sourceFormat && sourceFormat.value === "osm")
-                                            ? {
-                                                'application/octet-stream': ['.pbf', '.osm'],
-                                                'application/xml': ['.xml']
-                                              }
-                                            : jobType.value === "confidence" || jobType.value === "quality-metric"
-                                                ? { 'application/geo+json': ['.geojson'] }
-                                                : { 'application/zip': ['.zip'] }
-                                }
+                                    jobType.value === "osw-convert" && sourceFormat == null
+                                        ? "" 
+                                        : jobType.value === "quality-metric-tag"
+                                            ? { 'application/json': ['.json'] }
+                                            : jobType.value === "osw-convert" && (sourceFormat && sourceFormat.value === "osm")
+                                                ? {
+                                                    'application/octet-stream': ['.pbf', '.osm'],
+                                                    'application/xml': ['.xml']
+                                                  }
+                                                : jobType.value === "confidence" || jobType.value === "quality-metric"
+                                                    ? { 'application/geo+json': ['.geojson'] }
+                                                    : { 'application/zip': ['.zip'] }
+                                }                                
                                 format={
                                     jobType.value === "quality-metric-tag"
                                         ? ".json"
                                         : jobType.value === "osw-convert" && (sourceFormat && sourceFormat.value === "osm")
                                             ? ".pbf, .osm, .xml"
-                                            : jobType.value === "confidence" || jobType.value === "quality-metric"
-                                                ? ".geojson"
-                                                : ".zip"
+                                            : jobType.value === "osw-convert" && sourceFormat == null
+                                                ? "-"
+                                                : jobType.value === "confidence" || jobType.value === "quality-metric"
+                                                    ? ".geojson"
+                                                    : ".zip"
                                 }
                                 selectedFile={selectedFile}
                             />

--- a/tdei-ui/src/services/apiServices.js
+++ b/tdei-ui/src/services/apiServices.js
@@ -653,13 +653,22 @@ export async function cloneDataset(data) {
 
 export async function downloadDataset(data) {
   var file_end_point = ''
+  const params = {};
   var service_type = data.data_type
   if (service_type === 'flex') { file_end_point = 'gtfs-flex' }
   else if (service_type === 'pathways') { file_end_point = 'gtfs-pathways' }
   else { file_end_point = 'osw' }
+  if(service_type === 'osw'){
+    if (data.format) {
+      params.format = data.format;
+    }
+    if (data.file_version) {
+      params.file_version = data.file_version;
+    }
+  }
   try {
     const response = await axios.get(`${osmUrl}/${file_end_point}/${data.tdei_dataset_id}`, {
-      responseType: 'blob'
+      responseType: 'blob',params:params
     });
     const urlBlob = window.URL.createObjectURL(new Blob([response.data]));
     const a = document.createElement('a');
@@ -670,6 +679,7 @@ export async function downloadDataset(data) {
     a.remove();
     window.URL.revokeObjectURL(urlBlob);
   } catch (error) {
+    return Promise.reject(new AxiosError(error));
     console.error('There was a problem with the download operation:', error);
   }
 };


### PR DESCRIPTION
Task 1 - https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1345/
- There is already an existing condition for OSW convert job where depending on the source format, accepted file format changes. i,e OSM -> '.pbf', '.osm', '.xml' and OSW -> 'zip'. Earlier prior to source selection,'. zip' file upload was accepted. Now disabled file upload without source selection.

Task 2 - https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1341/
 - Added file version and format selection for OSW dataset download by displaying a selection modal. Default values 'OSW 'format and 'latest' version are selected. 

<img width="1470" alt="Screenshot 2024-10-17 at 12 28 30 PM" src="https://github.com/user-attachments/assets/9fe160bf-47c4-40e1-bcf2-14e5003ab940">
<img width="1470" alt="Screenshot 2024-10-17 at 12 03 11 PM" src="https://github.com/user-attachments/assets/482ea0d0-adb9-4b85-887f-4c4d14865116">
<img width="1470" alt="Screenshot 2024-10-17 at 12 02 35 PM" src="https://github.com/user-attachments/assets/6c306279-bb4d-4db0-8d31-d3be0a2d5878">
<img width="1470" alt="Screenshot 2024-10-17 at 12 02 56 PM" src="https://github.com/user-attachments/assets/38c35e18-2adf-4a4a-85df-6341c76e70fd">
<img width="1470" alt="Screenshot 2024-10-17 at 12 03 01 PM" src="https://github.com/user-attachments/assets/70aec9a1-613c-46fc-aac6-d37d9d4b2253">





