### PR TITLE
Feature-task-1734-Front-End: Member alert message changes and UI corrections

### DIFF
--- a/tdei-ui/public/style.css
+++ b/tdei-ui/public/style.css
@@ -85,3 +85,8 @@ body {
     font-style: italic;
     color: var(--primary-color-dark);
 }
+.last-updated {
+    font-style: italic;
+    color: var(--primary-color);
+    margin-bottom: 10px;
+}

--- a/tdei-ui/public/terms.html
+++ b/tdei-ui/public/terms.html
@@ -16,6 +16,7 @@
     </div>
     <div class="content-container">
         <h1>TDEI Terms & Conditions</h1>
+        <p class="last-updated">Last updated: <span>February 25, 2025</span></p>
         <p>
             By registering for and using the TDEI portal, you acknowledge and agree to the following terms:
         </p>

--- a/tdei-ui/src/components/UserHeader/UserHeader.js
+++ b/tdei-ui/src/components/UserHeader/UserHeader.js
@@ -92,7 +92,7 @@ const UserHeader = ({ roles }) => {
                 setCopy(true);
                 setTimeout(() => setCopy(false), 2000);
               }}>
-                <Button variant="link">{copy ? "Copied!" : "Copy"}</Button>
+                <Button style={{ minWidth: "70px" }} variant="link">{copy ? "Copied!" : "Copy"}</Button>
               </CopyToClipboard>
               <div className={style.verticalLine}></div>
               <Tooltip title="Regenerate API Key" arrow>

--- a/tdei-ui/src/components/UserHeader/UserHeader.js
+++ b/tdei-ui/src/components/UserHeader/UserHeader.js
@@ -77,11 +77,19 @@ const UserHeader = ({ roles }) => {
         <div className={style.apiKey}>
           <div>My API Key</div>
           <div className={style.maskedKey} style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-            {isLoading ? (
-              <span className={style.font14}>loading api key...</span>
-            ) : (
-              <>{showApiKey ? <div className={style.keyVisible}>{API_KEY}</div> : <div className={style.keyHidden}>{maskedKey}</div>}</>
-            )}
+            <div className={style.keyContainer}>
+              {isLoading ? (
+                <span className={style.font14}>loading api key...</span>
+              ) : (
+                <>
+                  {showApiKey ? (
+                    <div className={style.keyVisible}>{API_KEY}</div>
+                  ) : (
+                    <div className={style.keyHidden}>{maskedKey}</div>
+                  )}
+                </>
+              )}
+            </div>
 
             <div className={style.buttonContainer}>
               <Button variant="link" onClick={() => setShowApiKey(!showApiKey)}>
@@ -96,12 +104,14 @@ const UserHeader = ({ roles }) => {
               </CopyToClipboard>
               <div className={style.verticalLine}></div>
               <Tooltip title="Regenerate API Key" arrow>
-                <Button
-                  variant="link"
-                  onClick={regenerateKey}
-                  disabled={isRegenerating}
-                >
-                  {isRegenerating ? <Spinner animation="border" size="sm" /> : <CachedIcon />}
+                <Button variant="link" onClick={regenerateKey} disabled={isRegenerating}>
+                  <div className={style.fixedIcon}>
+                    {isRegenerating ? (
+                      <Spinner animation="border" size="sm" style={{ width: "20px", height: "20px" }} />
+                    ) : (
+                      <CachedIcon style={{ fontSize: "20px" }} />
+                    )}
+                  </div>
                 </Button>
               </Tooltip>
             </div>

--- a/tdei-ui/src/components/UserHeader/UserHeader.module.css
+++ b/tdei-ui/src/components/UserHeader/UserHeader.module.css
@@ -46,6 +46,7 @@
   justify-content: space-between;
   padding: 5px 15px 5px 15px;
   margin-left: 10px;
+  min-width: 525px;
 }
 .buttonContainer {
   display: flex;

--- a/tdei-ui/src/components/UserHeader/UserHeader.module.css
+++ b/tdei-ui/src/components/UserHeader/UserHeader.module.css
@@ -29,6 +29,9 @@
   color: #6e7897;
   display: flex;
   align-items: center;
+  overflow-x: auto;
+  white-space: nowrap;
+  max-width: 100%;
 }
 .projectId {
   padding-top: 20px;
@@ -47,10 +50,13 @@
   padding: 5px 15px 5px 15px;
   margin-left: 10px;
   min-width: 525px;
+  overflow:hidden;
+  flex-shrink: 0;
 }
 .buttonContainer {
   display: flex;
   margin-left: 20px;
+  flex-wrap: nowrap;
 }
 
 .verticalLine {
@@ -77,3 +83,34 @@
 .font14 {
   font-size: 14px;
 }
+.keyContainer {
+  flex-grow: 1;
+  overflow: scroll;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+@media screen and (max-width: 768px) {
+  .apiKey {
+    overflow-x: auto; 
+    white-space: nowrap;
+    flex-wrap: nowrap;
+    padding-bottom: 5px;
+  }
+
+  .maskedKey {
+    min-width: 525px;
+    width: auto;
+    max-width: none;
+  }
+
+  .buttonContainer {
+    margin-left: 5px;
+    flex-wrap: nowrap; 
+  }
+
+  .buttonContainer button {
+    font-size: 12px; 
+    padding: 3px 6px;
+  }
+}
+

--- a/tdei-ui/src/components/VerticalStepper/VerticalStepper.js
+++ b/tdei-ui/src/components/VerticalStepper/VerticalStepper.js
@@ -240,7 +240,7 @@ export default function VerticalStepper({ stepsData, onStepsComplete,currentStep
     }
     const requiredRole = `${selectedData[0]?.service_type}_data_generator`;
     if (!(isAdmin || projectRoles.includes("poc") || projectRoles.includes(requiredRole))) {
-      return `You need ${requiredRole} role to upload this service.`;
+      return `You need ${requiredRole} role to select this service.`;
     }
     return null;
   };

--- a/tdei-ui/src/components/VerticalStepper/VerticalStepper.js
+++ b/tdei-ui/src/components/VerticalStepper/VerticalStepper.js
@@ -240,7 +240,11 @@ export default function VerticalStepper({ stepsData, onStepsComplete,currentStep
     }
     const requiredRole = `${selectedData[0]?.service_type}_data_generator`;
     if (!(isAdmin || projectRoles.includes("poc") || projectRoles.includes(requiredRole))) {
-      return `You need ${requiredRole} role to select this service.`;
+      return (
+        <>
+          You need <strong>{requiredRole}</strong> role to select this service.
+        </>
+      );
     }
     return null;
   };

--- a/tdei-ui/src/routes/CloneDataset/CloneDatasetStepper.js
+++ b/tdei-ui/src/routes/CloneDataset/CloneDatasetStepper.js
@@ -329,11 +329,16 @@ export default function CloneDatasetStepper({ stepsData, onStepsComplete, curren
     }
     const datasetType = dataset.data_type;
     const requiredRole = `${datasetType}_data_generator`;
+    const projectGroupName = selectedData[0]?.project_group_name ?? "";
     
     const hasValidRole = userRoles.includes(requiredRole) || userRoles.includes("poc") || isAdmin;
     
     if (!hasValidRole) {
-      return `You need ${requiredRole} role to clone this dataset.`;
+      return (
+        <>
+          To clone this dataset to project group <strong>{projectGroupName}</strong>, you need <strong>{requiredRole}</strong> role in <strong>{projectGroupName}</strong>.
+        </>
+      );
     }
     return null;
   };


### PR DESCRIPTION
###  DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1734

## Changes Introduced  
- Updated the error message for cloning datasets. The new message specifies the required role and project group format:  
  **Old:** "You need _data_generator role to clone this project group."  
  **New:** "To clone this dataset to project group Y, you need x_data_generator role in Y."  
- Fixed the API key width by applying a constant width.  
- Added a "Last Updated" timestamp to the Terms & Conditions page.  

## Impacted Areas for Testing  

1. **Dataset Cloning Message Update**  
   - Verify that the updated message appears correctly when a user without the required role attempts to clone a dataset.  
   - Ensure the project group name (`Y`) and required role (`x_data_generator`) are dynamically populated based on the context.  

2. **API Key Width Fix**  
   - Confirm that the API key now maintains a consistent width across different screen sizes.  

3. **Last Updated Timestamp in Terms & Conditions**  
   - Check that the "Last Updated" timestamp appears correctly on the Terms & Conditions page.
## Screenshots
<img width="1470" alt="Screenshot 2025-02-25 at 5 25 15 PM" src="https://github.com/user-attachments/assets/74fe6acb-8ef9-4266-853b-ec9e746afca8" />
<img width="1470" alt="Screenshot 2025-02-25 at 7 04 26 PM" src="https://github.com/user-attachments/assets/9e7145ad-4c4a-4928-b60f-2065efb25541" />
<img width="1470" alt="Screenshot 2025-02-25 at 7 04 38 PM" src="https://github.com/user-attachments/assets/19435a79-2ac3-4bd7-b556-deb22b3d2019" />
<img width="1470" alt="Screenshot 2025-02-25 at 7 05 58 PM" src="https://github.com/user-attachments/assets/3d43e788-c528-4778-adbf-403259cb7d07" />
