### PR TITLE
Feature-task-1744-Remember the current selected project group until logout

### DIFF
--- a/tdei-ui/src/components/AuthProvider/AuthProvider.js
+++ b/tdei-ui/src/components/AuthProvider/AuthProvider.js
@@ -5,9 +5,12 @@ import { useLocation, useNavigate } from "react-router-dom";
 import ReLoginModal from "../ReLoginModal/ReLoginModal";
 import { setTokenExpiredCallback } from "../../services/tokenEventEmitter";
 import ResponseToast from "../ToastMessage/ResponseToast";
+import { clear } from "../../store";
+import { useDispatch } from "react-redux";
 
 const AuthProvider = ({ children }) => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const location = useLocation();
   const [user, setUser] = useState(null);
   const [isReLoginOpen, setIsReLoginOpen] = useState(false);
@@ -20,6 +23,14 @@ const AuthProvider = ({ children }) => {
       const base64Url = accessToken.split(".")[1];
       const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
       const decodedToken = JSON.parse(window.atob(base64));
+          // Check if the token is expired
+          if (decodedToken.exp * 1000 < Date.now()) { 
+            console.warn("Token has expired. Logging out...");
+            localStorage.removeItem("accessToken");
+            localStorage.removeItem("refreshToken");
+            dispatch(clear());
+            return null; 
+        }
       return decodedToken;
     } catch (error) {
       console.error("Failed to decode token:", error);
@@ -146,6 +157,7 @@ const AuthProvider = ({ children }) => {
   const signout = () => {
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
+    dispatch(clear());
     setUser(null);
     navigate("/login");
   };

--- a/tdei-ui/src/components/AuthProvider/AuthProvider.js
+++ b/tdei-ui/src/components/AuthProvider/AuthProvider.js
@@ -25,7 +25,6 @@ const AuthProvider = ({ children }) => {
       const decodedToken = JSON.parse(window.atob(base64));
           // Check if the token is expired
           if (decodedToken.exp * 1000 < Date.now()) { 
-            console.warn("Token has expired. Logging out...");
             localStorage.removeItem("accessToken");
             localStorage.removeItem("refreshToken");
             dispatch(clear());

--- a/tdei-ui/src/components/Header/Header.js
+++ b/tdei-ui/src/components/Header/Header.js
@@ -11,6 +11,7 @@ import resetPasswordIcon from "../../assets/img/reset_pass.svg";
 import logoutIcon from "../../assets/img/logout.svg";
 import ResetPassword from "../ResetPassword/ResetPassword";
 import useResetPassword from "../../hooks/useResetPassword";
+import { clear } from "../../store";
 
 const Header = () => {
   const dispatch = useDispatch();
@@ -21,6 +22,7 @@ const Header = () => {
   const handleLogout = () => {
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
+    dispatch(clear());
     window.location.reload();
   };
   const handleResetPassword = () => {

--- a/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitch.js
+++ b/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitch.js
@@ -51,14 +51,7 @@ const ProjectGroupSwitch = () => {
         useEffect(() => {
             const handleStorageChange = (event) => {
                 if (event.key === "selectedProjectGroup") {
-                    console.log("Storage event detected. New value:", event.newValue);
                     const updatedProjectGroup = JSON.parse(localStorage.getItem("selectedProjectGroup"));
-                    
-                    if (updatedProjectGroup) {
-                        console.log("Updated Project Group:", updatedProjectGroup);
-                        console.log("Name:", updatedProjectGroup.name);
-                    }
-        
                     if (updatedProjectGroup && updatedProjectGroup.tdei_project_group_id !== selectedProjectGroup?.tdei_project_group_id) {
                         dispatch(set(updatedProjectGroup));
                     }

--- a/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitch.js
+++ b/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitch.js
@@ -47,6 +47,29 @@ const ProjectGroupSwitch = () => {
             navigate("/");
         }
     }
+        // Sync Redux state when localStorage changes (cross-tab update)
+        useEffect(() => {
+            const handleStorageChange = (event) => {
+                if (event.key === "selectedProjectGroup") {
+                    console.log("Storage event detected. New value:", event.newValue);
+                    const updatedProjectGroup = JSON.parse(localStorage.getItem("selectedProjectGroup"));
+                    
+                    if (updatedProjectGroup) {
+                        console.log("Updated Project Group:", updatedProjectGroup);
+                        console.log("Name:", updatedProjectGroup.name);
+                    }
+        
+                    if (updatedProjectGroup && updatedProjectGroup.tdei_project_group_id !== selectedProjectGroup?.tdei_project_group_id) {
+                        dispatch(set(updatedProjectGroup));
+                    }
+                }
+            };
+        
+            window.addEventListener("storage", handleStorageChange);
+            return () => window.removeEventListener("storage", handleStorageChange);
+        }, [dispatch, selectedProjectGroup?.tdei_project_group_id]);
+        
+        
     const handleSearch = (e) => {
         setDebounceQuery(e.target.value);
     };

--- a/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcherDropDown.js
+++ b/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcherDropDown.js
@@ -29,7 +29,6 @@ const ProjectGroupSwitcherDropDown = () => {
       );
       // Only clear selection if the project is confirmed to be deleted
       if (!projectExists) {
-        console.warn("Selected project no longer exists. Clearing selection...");
         dispatch(clear());
       }
     }
@@ -60,7 +59,6 @@ const ProjectGroupSwitcherDropDown = () => {
     ) {
       const firstProjectGroup = data.pages[0].data[0];
       if (firstProjectGroup) {
-        console.log("Setting first project group:", firstProjectGroup);
         dispatch(set(firstProjectGroup));
       }
     }

--- a/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcherDropDown.js
+++ b/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcherDropDown.js
@@ -6,16 +6,64 @@ import { getSelectedProjectGroup } from "../../selectors";
 import { set } from "../../store";
 import style from "./ProjectGroupSwitcher.module.css";
 import useGetProjectGroupRoles from "../../hooks/roles/useProjectGroupRoles";
+import { clear } from "../../store";
 
 const ProjectGroupSwitcherDropDown = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const selectedProjectGroup = useSelector(getSelectedProjectGroup);
-  const {  data = [] } = useGetProjectGroupRoles();
+  const { data = [] } = useGetProjectGroupRoles();
 
+  // // Load initial value from localStorage when component mounts
+  // useEffect(() => {
+  //   const savedProjectGroup = JSON.parse(localStorage.getItem("selectedProjectGroup"));
+  //   if (savedProjectGroup && !selectedProjectGroup?.tdei_project_group_id) {
+  //     dispatch(set(savedProjectGroup));
+  //   }
+  // }, [dispatch, selectedProjectGroup]);
+  useEffect(() => {
+    const savedProjectGroup = JSON.parse(localStorage.getItem("selectedProjectGroup"));
+
+    // Load from localStorage only if Redux doesn't have a project selected
+    if (savedProjectGroup && !selectedProjectGroup?.tdei_project_group_id) {
+      dispatch(set(savedProjectGroup));
+    }
+    // Only run this check if data has been fetched
+    if (selectedProjectGroup?.tdei_project_group_id && data?.pages?.length > 0) {
+      const projectExists = data.pages.some(page =>
+        page.data.some(proj => proj.tdei_project_group_id === selectedProjectGroup.tdei_project_group_id)
+      );
+      // Only clear selection if the project is confirmed to be deleted
+      if (!projectExists) {
+        console.warn("Selected project no longer exists. Clearing selection...");
+        dispatch(clear());
+      }
+    }
+  }, [dispatch, selectedProjectGroup, data]);
+
+
+  // Sync Redux when localStorage changes (cross-tab updates)
+  useEffect(() => {
+    const handleStorageChange = (event) => {
+      if (event.key === "selectedProjectGroup") {
+        const updatedProjectGroup = JSON.parse(event.newValue);
+        if (updatedProjectGroup && updatedProjectGroup.tdei_project_group_id !== selectedProjectGroup?.tdei_project_group_id) {
+          dispatch(set(updatedProjectGroup));
+        }
+      }
+    };
+
+    window.addEventListener("storage", handleStorageChange);
+    return () => window.removeEventListener("storage", handleStorageChange);
+  }, [dispatch, selectedProjectGroup?.tdei_project_group_id]);
+
+  // Auto-select the first available project group if none is selected
   useEffect(() => {
     const isEmptyObject = (obj) => Object.keys(obj).length === 0;
-    if ((selectedProjectGroup === null || isEmptyObject(selectedProjectGroup)) && data?.pages?.[0]?.data?.length > 0) {
+    if (
+      (selectedProjectGroup === null || isEmptyObject(selectedProjectGroup)) &&
+      data?.pages?.[0]?.data?.length > 0
+    ) {
       const firstProjectGroup = data.pages[0].data[0];
       if (firstProjectGroup) {
         console.log("Setting first project group:", firstProjectGroup);
@@ -23,18 +71,18 @@ const ProjectGroupSwitcherDropDown = () => {
       }
     }
   }, [data, dispatch, selectedProjectGroup]);
-  
+
   return (
     <div style={{ marginRight: "1rem" }}>
       <div className={style.projectGroupLabel}>Project Group</div>
       <Dropdown className={style.customDropdown} align="end">
         <Dropdown.Toggle as={CustomToggle} id="dropdown-custom-components">
           <div className={style.selectedProjectGroupName}>
-            {selectedProjectGroup.name || "Select Project Group"}
+            {selectedProjectGroup?.name || "Select Project Group"}
           </div>
         </Dropdown.Toggle>
         <Dropdown.Menu>
-          <Dropdown.Header>{selectedProjectGroup.name || "Switch Project Group"}</Dropdown.Header>
+          <Dropdown.Header>{selectedProjectGroup?.name || "Switch Project Group"}</Dropdown.Header>
           <Dropdown.Item onClick={() => navigate("/projectGroupSwitch")}>
             Switch Project Group
           </Dropdown.Item>

--- a/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcherDropDown.js
+++ b/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcherDropDown.js
@@ -15,12 +15,6 @@ const ProjectGroupSwitcherDropDown = () => {
   const { data = [] } = useGetProjectGroupRoles();
 
   // // Load initial value from localStorage when component mounts
-  // useEffect(() => {
-  //   const savedProjectGroup = JSON.parse(localStorage.getItem("selectedProjectGroup"));
-  //   if (savedProjectGroup && !selectedProjectGroup?.tdei_project_group_id) {
-  //     dispatch(set(savedProjectGroup));
-  //   }
-  // }, [dispatch, selectedProjectGroup]);
   useEffect(() => {
     const savedProjectGroup = JSON.parse(localStorage.getItem("selectedProjectGroup"));
 

--- a/tdei-ui/src/components/ReLoginModal/ReLoginModal.js
+++ b/tdei-ui/src/components/ReLoginModal/ReLoginModal.js
@@ -5,10 +5,12 @@ import * as yup from "yup";
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import style from './ReLoginModal.module.css';
+import { useDispatch } from "react-redux";
+import { clear } from "../../store";
 
 const ReLoginModal = ({ open, onClose, onReLogin, email }) => {
   const [showPassword, setShowPassword] = useState(false);
-
+  const dispatch = useDispatch();
   const validationSchema = yup.object().shape({
     password: yup.string().required("Password is required"),
   });
@@ -19,6 +21,7 @@ const ReLoginModal = ({ open, onClose, onReLogin, email }) => {
   const handleLogout = () => {
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
+    dispatch(clear()); 
     window.location.reload();
   };
 

--- a/tdei-ui/src/components/ResetPassword/ResetPassword.js
+++ b/tdei-ui/src/components/ResetPassword/ResetPassword.js
@@ -11,6 +11,7 @@ import ResponseToast from "../ToastMessage/ResponseToast";
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import style from './ResetPassword.module.css';
+import { clear } from "../../store";
 
 const ResetPassword = (props) => {
   const { user } = useAuth();
@@ -48,6 +49,7 @@ const ResetPassword = (props) => {
     setTimeout(() => {
       localStorage.removeItem("accessToken");
       localStorage.removeItem("refreshToken");
+      dispatch(clear());
       window.location.reload();
     }, 2000);
   };

--- a/tdei-ui/src/hooks/service/useGetReleaseDatasets.js
+++ b/tdei-ui/src/hooks/service/useGetReleaseDatasets.js
@@ -6,13 +6,14 @@ import { GET_DATASETS } from "../../utils";
 import { getReleasedDatasets } from "../../services";
 
 function useGetReleasedDatasets(searchText = "",debounceDatasetIdQuery = "", dataType, projectId = "", validFrom = null, validTo = null, tdeiServiceId,sortField, sortOrder) {
-  const { tdei_project_group_id } = useSelector(getSelectedProjectGroup);
+  const selectedProjectGroup = useSelector(getSelectedProjectGroup);
+  const tdei_project_group_id = projectId === "" ? selectedProjectGroup?.tdei_project_group_id : projectId;
   const [refreshKey, setRefreshKey] = useState(0);
 
   const { data, isError, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery(
-    [GET_DATASETS, searchText,debounceDatasetIdQuery, dataType, tdei_project_group_id, refreshKey, projectId, validFrom, validTo,tdeiServiceId,sortField, sortOrder],
+    [GET_DATASETS, searchText,debounceDatasetIdQuery, dataType, tdei_project_group_id, refreshKey, validFrom, validTo,tdeiServiceId,sortField, sortOrder],
     ({ pageParam }) =>
-      getReleasedDatasets(searchText, debounceDatasetIdQuery, pageParam, dataType, projectId, validFrom, validTo,tdeiServiceId,sortField, sortOrder),
+      getReleasedDatasets(searchText, debounceDatasetIdQuery, pageParam, dataType, tdei_project_group_id, validFrom, validTo,tdeiServiceId,sortField, sortOrder),
     {
       getNextPageParam: (lastPage) => {
         return lastPage.data.length > 0 && lastPage.data.length === 10

--- a/tdei-ui/src/hooks/service/useGetReleaseDatasets.js
+++ b/tdei-ui/src/hooks/service/useGetReleaseDatasets.js
@@ -6,14 +6,13 @@ import { GET_DATASETS } from "../../utils";
 import { getReleasedDatasets } from "../../services";
 
 function useGetReleasedDatasets(searchText = "",debounceDatasetIdQuery = "", dataType, projectId = "", validFrom = null, validTo = null, tdeiServiceId,sortField, sortOrder) {
-  const selectedProjectGroup = useSelector(getSelectedProjectGroup);
-  const tdei_project_group_id = projectId === "" ? selectedProjectGroup?.tdei_project_group_id : projectId;
+  const { tdei_project_group_id } = useSelector(getSelectedProjectGroup);
   const [refreshKey, setRefreshKey] = useState(0);
 
   const { data, isError, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery(
-    [GET_DATASETS, searchText,debounceDatasetIdQuery, dataType, tdei_project_group_id, refreshKey, validFrom, validTo,tdeiServiceId,sortField, sortOrder],
+    [GET_DATASETS, searchText,debounceDatasetIdQuery, dataType, tdei_project_group_id, refreshKey, projectId, validFrom, validTo,tdeiServiceId,sortField, sortOrder],
     ({ pageParam }) =>
-      getReleasedDatasets(searchText, debounceDatasetIdQuery, pageParam, dataType, tdei_project_group_id, validFrom, validTo,tdeiServiceId,sortField, sortOrder),
+      getReleasedDatasets(searchText, debounceDatasetIdQuery, pageParam, dataType, projectId, validFrom, validTo,tdeiServiceId,sortField, sortOrder),
     {
       getNextPageParam: (lastPage) => {
         return lastPage.data.length > 0 && lastPage.data.length === 10

--- a/tdei-ui/src/services/axiosService.js
+++ b/tdei-ui/src/services/axiosService.js
@@ -111,6 +111,7 @@ axios.interceptors.response.use(
       //----------------------------
       localStorage.removeItem("accessToken");
       localStorage.removeItem("refreshToken");
+      localStorage.removeItem("selectedProjectGroup");
       if (originalRequest.session_timeout_login_request != undefined && originalRequest.session_timeout_login_request) {
         //----------------------------
         //Case when re login fails on session timeout popup

--- a/tdei-ui/src/store/projectGroupRoles.slice.js
+++ b/tdei-ui/src/store/projectGroupRoles.slice.js
@@ -1,18 +1,45 @@
-import { createSlice } from "@reduxjs/toolkit";
+// import { createSlice } from "@reduxjs/toolkit";
 
-const initialState = {};
+// const initialState = {};
+
+// const projectGroupRolesSlice = createSlice({
+//   name: "selectedProjectGroup",
+//   initialState,
+//   reducers: {
+//     set(state, action) {
+//       state.name = action.payload.project_group_name;
+//       state.tdei_project_group_id = action.payload.tdei_project_group_id;
+//       state.roles = action.payload.roles;
+//     },
+//   },
+// });
+
+// export const { set } = projectGroupRolesSlice.actions;
+// export default projectGroupRolesSlice.reducer;
+
+import { createSlice } from "@reduxjs/toolkit";
 
 const projectGroupRolesSlice = createSlice({
   name: "selectedProjectGroup",
-  initialState,
+  initialState: JSON.parse(localStorage.getItem("selectedProjectGroup")) || {},
   reducers: {
     set(state, action) {
-      state.name = action.payload.project_group_name;
-      state.tdei_project_group_id = action.payload.tdei_project_group_id;
-      state.roles = action.payload.roles;
+      const newState = {
+        name: action.payload.project_group_name || action.payload.name,
+        tdei_project_group_id: action.payload.tdei_project_group_id,
+        roles: action.payload.roles || [],
+      };
+      console.log("Saving to localStorage:", newState);
+      localStorage.setItem("selectedProjectGroup", JSON.stringify(newState));
+      return newState;
+    },
+    clear() {
+      localStorage.removeItem("selectedProjectGroup");
+      return {};
     },
   },
 });
 
-export const { set } = projectGroupRolesSlice.actions;
+
+export const { set, clear } = projectGroupRolesSlice.actions;
 export default projectGroupRolesSlice.reducer;

--- a/tdei-ui/src/store/projectGroupRoles.slice.js
+++ b/tdei-ui/src/store/projectGroupRoles.slice.js
@@ -29,7 +29,6 @@ const projectGroupRolesSlice = createSlice({
         tdei_project_group_id: action.payload.tdei_project_group_id,
         roles: action.payload.roles || [],
       };
-      console.log("Saving to localStorage:", newState);
       localStorage.setItem("selectedProjectGroup", JSON.stringify(newState));
       return newState;
     },

--- a/tdei-ui/src/store/projectGroupRoles.slice.js
+++ b/tdei-ui/src/store/projectGroupRoles.slice.js
@@ -1,22 +1,3 @@
-// import { createSlice } from "@reduxjs/toolkit";
-
-// const initialState = {};
-
-// const projectGroupRolesSlice = createSlice({
-//   name: "selectedProjectGroup",
-//   initialState,
-//   reducers: {
-//     set(state, action) {
-//       state.name = action.payload.project_group_name;
-//       state.tdei_project_group_id = action.payload.tdei_project_group_id;
-//       state.roles = action.payload.roles;
-//     },
-//   },
-// });
-
-// export const { set } = projectGroupRolesSlice.actions;
-// export default projectGroupRolesSlice.reducer;
-
 import { createSlice } from "@reduxjs/toolkit";
 
 const projectGroupRolesSlice = createSlice({


### PR DESCRIPTION
## DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1711

## Changes Introduced
- Ensured that the selected project group persists across browser refresh and back events instead of defaulting to the first available project.
- Selected project group now remains active until logout or explicit selection of another project.
- Fixed cross-tab synchronization, ensuring that project group selection updates automatically across multiple open tabs.
- Cleared project group selection upon logout to prevent unauthorized usage.


---

## Impacted Areas for Testing

### 1. General Functionality
| Test Case | Steps | Expected Behavior | Pass/Fail |
|-----------|-------|------------------|-----------|
| **Login** | By default, the first project group in the list gets selected. | The first project group in the list gets selected. | Pass |
| **Page Refresh** | 1. Select a project group <br> 2. Refresh the page | The selected project group persists. | Pass |
| **Cross-Tab Sync** | 1. Select a project in Tab 1 <br> 2. Open Tab 2 <br> 3. Switch project in Tab 2 <br> 4. Return to Tab 1 | The project updates automatically in Tab 1. | Pass |
| **Logout** | 1. Select a project group <br> 2. Logout <br> 3. Log back in | The project group is cleared. | Pass |

### 2. Jobs Management
| Test Case | Steps | Expected Behavior | Pass/Fail |
|-----------|-------|------------------|-----------|
| **View Jobs** | 1. Navigate to Jobs <br> 2. View the API request and response | Jobs are fetched with the accurate project group ID. | Pass |
| **Create Jobs** | 1. Navigate to Jobs <br> 2. Select a job type <br> 3. Try creating a job | The job is created with the correct project ID. | Pass |

### 3. Datasets Management
| Test Case | Steps | Expected Behavior | Pass/Fail |
|-----------|-------|------------------|-----------|
| **View Datasets** | 1. Navigate to Datasets <br> 2. View the API request and response | Datasets are fetched with the accurate project group ID. | Pass |
| **Datasets Upload** | 1. Select a project <br> 2. Upload a dataset <br> 3. Check API request payload | The `tdei_project_group_id` is included in the request. | Pass |
| **Edit Metadata** | 1. Select a project <br> 2. Open a dataset for editing | Upon editing, metadata request should go with the appropriate project group. | Pass |

### 4. Members Management
| Test Case | Steps | Expected Behavior | Pass/Fail |
|-----------|-------|------------------|-----------|
| **Verify Members List** | 1. Select a project <br> 2. Open Members Management | Only members of the selected project group are displayed. | Pass |

### 5. Services Management
| Test Case | Steps | Expected Behavior | Pass/Fail |
|-----------|-------|------------------|-----------|
| **Create Service** | 1. Select a project <br> 2. Create a service <br> 3. Submit the form | The service is created under the selected project. | Pass |
| **View Services List** | 1. Select a project <br> 2. Open View Services | Only services from the selected project are listed. | Pass |

### 6. Roles & Permissions Management
| Test Case | Steps | Expected Behavior | Pass/Fail |
|-----------|-------|------------------|-----------|
| **Assign Roles** | 1. Select a project <br> 2. Assign a role <br> 3. Check API request payload | The correct `tdei_project_group_id` is included in the request. | Pass |

