### PR TITLE
Feature-task-1756-Add download metadata action button & Project Group Selection Dropdown UI Changes

### DIFF
--- a/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcher.module.css
+++ b/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcher.module.css
@@ -211,13 +211,48 @@
   font-weight: bold;
   background-color: #e9ecef;
   pointer-events: none;
+  font-size: 14px;
+  padding: 6px 12px;
 }
 
 .seeAllOptions {
+  padding: 8px;
   font-weight: bold;
-  text-align: center;
+  text-align: left;
   color:var(--primary-color);
+  font-size: 16px;
 }
 .seeAllOptions:hover {
   background-color: #f8f9fa;
+}
+.currentProjectGroupContainer,
+.dropdownHeader {
+  padding: 8px;
+  font-size: 16px;
+  text-align: left;
+  font-weight: bold;
+  color: #333;
+}
+
+.currentProjectGroupLabel {
+  padding: 8px 0;
+  font-weight: bold;
+  color: #555;
+  display: block;
+  font-size: 16px;
+}
+
+.currentProjectGroupName {
+  font-size: 14px;
+  color:var(--primary-color);
+  padding: 0px 4px 0px;
+}
+
+.projectGroupNames {
+  font-size: 14px;
+  padding: 6px 12px;
+}
+.dropdownMenu {
+  min-width: 240px;
+  padding: 8px;
 }

--- a/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcherDropDown.js
+++ b/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcherDropDown.js
@@ -68,7 +68,7 @@ const ProjectGroupSwitcherDropDown = () => {
   const limitedProjectGroups = projectGroups.slice(0, 5);
 
   return (
-    <div style={{ marginRight: "1rem" }}>
+    <div style={{ marginRight: "1rem",alignSelf:'end' }}>
       <div className={style.projectGroupLabel}>Project Group</div>
       <Dropdown className={style.customDropdown} align="end">
         <Dropdown.Toggle as={CustomToggle} id="dropdown-custom-components">
@@ -76,7 +76,15 @@ const ProjectGroupSwitcherDropDown = () => {
             {selectedProjectGroup?.name || "Select Project Group"}
           </div>
         </Dropdown.Toggle>
-        <Dropdown.Menu>
+        <Dropdown.Menu className={style.dropdownMenu}>
+        <div className={style.currentProjectGroupContainer}>
+            <span className={style.currentProjectGroupLabel}>Current Project Group:</span>
+            <span className={style.currentProjectGroupName}>
+              {selectedProjectGroup?.name || "None Selected"}
+            </span>
+          </div>
+        <Dropdown.Divider />
+        <Dropdown.Header className={style.dropdownHeader}>{"Switch Project Group"}</Dropdown.Header>
           {limitedProjectGroups.map((projectGroup) => (
             <Dropdown.Item
               key={projectGroup.tdei_project_group_id}
@@ -89,7 +97,7 @@ const ProjectGroupSwitcherDropDown = () => {
               className={
                 projectGroup.tdei_project_group_id === selectedProjectGroup?.tdei_project_group_id
                   ? style.selectedProjectGroupItem
-                  : ""
+                  : style.projectGroupNames
               }
             >
               {projectGroup.project_group_name}
@@ -103,7 +111,7 @@ const ProjectGroupSwitcherDropDown = () => {
                 onClick={() => navigate("/projectGroupSwitch")}
                 className={style.seeAllOptions}
               >
-                See all options
+                See All Groups
               </Dropdown.Item>
             </>
           )}

--- a/tdei-ui/src/routes/Datasets/DatasetsActions.js
+++ b/tdei-ui/src/routes/Datasets/DatasetsActions.js
@@ -57,6 +57,13 @@ const DatasetsActions = ({ status, onAction, isReleasedDataset, data_type }) => 
       icon: editImage,
       condition: true,
     },
+    // "Download Metadata" is available if the user is isDataGenerator || user?.isAdmin || isMember
+    canClone && {
+      key: "downloadMetadata",
+      label: "Download Metadata",
+      icon: downloadDatasetImg,
+      condition: true,
+    },
     // "Add Inclination" is available for non-released OSW datasets if the user is OSW generator and the status isn't "Publish"
     !isReleasedDataset && canAddIncline && status !== "Publish" && data_type === 'osw' && {
       key: "inclination",

--- a/tdei-ui/src/routes/Datasets/DatasetsActions.js
+++ b/tdei-ui/src/routes/Datasets/DatasetsActions.js
@@ -57,8 +57,8 @@ const DatasetsActions = ({ status, onAction, isReleasedDataset, data_type }) => 
       icon: editImage,
       condition: true,
     },
-    // "Download Metadata" is available if the user is isDataGenerator || user?.isAdmin || isMember
-    canClone && {
+    // "Download Metadata" is available to all users
+   {
       key: "downloadMetadata",
       label: "Download Metadata",
       icon: downloadDatasetImg,


### PR DESCRIPTION
## DevBoard Task 
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1756

## Changes Introduced
- Added a 'Download Metadata' action button in the datasets list dropdown.
- Clicking the 'Download Metadata' button extracts the `metadata` field from the dataset and downloads it as a JSON file.
- Implemented error handling to prevent downloading an empty or missing metadata file.
- Made this button accessible to roles 'members' and above.

## Impacted Areas for Testing
- Verify that the 'Download Metadata' button appears in the dropdown action menu.
- Ensure that clicking the button triggers a metadata JSON file download.
- Confirm that the downloaded file contains valid metadata.

## Screenshots
<img width="1470" alt="Screenshot 2025-03-06 at 4 03 09 PM" src="https://github.com/user-attachments/assets/9867b24f-2bd6-4e89-9efe-4fcbdca87915" />

--- 

## DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1749

## Changes Introduced  
- Added 'Current Project Group' section in the dropdown.
- Added 'Switch Project Group' header.
- Ensured `currentProjectGroupName` and `projectGroupNames` are aligned properly.  
- Matched **padding, display, and text alignment** across elements.  

## Impacted Areas for Testing  
- Verify that Current Project Group Name and Project Group Names are properly aligned.  
- Ensure that the spacing between label and name is consistent.  

## Screenshots  
<img width="1470" alt="Screenshot 2025-03-07 at 2 20 27 PM" src="https://github.com/user-attachments/assets/c75c91b0-c421-44e4-a0ac-e735371ea90d" />

