### PR TITLE
Feature-task-1749-Add project groups to switcher dropdown & Task-1748-Hide upload dataset button for admin

### DIFF
--- a/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcher.module.css
+++ b/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcher.module.css
@@ -207,3 +207,17 @@
   border-radius: 5px;
   background: #fff;
 }
+.selectedProjectGroupItem {
+  font-weight: bold;
+  background-color: #e9ecef;
+  pointer-events: none;
+}
+
+.seeAllOptions {
+  font-weight: bold;
+  text-align: center;
+  color:var(--primary-color);
+}
+.seeAllOptions:hover {
+  background-color: #f8f9fa;
+}

--- a/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcherDropDown.js
+++ b/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitcherDropDown.js
@@ -64,6 +64,9 @@ const ProjectGroupSwitcherDropDown = () => {
     }
   }, [data, dispatch, selectedProjectGroup]);
 
+  const projectGroups = data?.pages?.flatMap((page) => page.data) || [];
+  const limitedProjectGroups = projectGroups.slice(0, 5);
+
   return (
     <div style={{ marginRight: "1rem" }}>
       <div className={style.projectGroupLabel}>Project Group</div>
@@ -74,14 +77,41 @@ const ProjectGroupSwitcherDropDown = () => {
           </div>
         </Dropdown.Toggle>
         <Dropdown.Menu>
-          <Dropdown.Header>{selectedProjectGroup?.name || "Switch Project Group"}</Dropdown.Header>
-          <Dropdown.Item onClick={() => navigate("/projectGroupSwitch")}>
-            Switch Project Group
-          </Dropdown.Item>
+          {limitedProjectGroups.map((projectGroup) => (
+            <Dropdown.Item
+              key={projectGroup.tdei_project_group_id}
+              onClick={() => {
+                if (projectGroup.tdei_project_group_id !== selectedProjectGroup?.tdei_project_group_id) {
+                  dispatch(set(projectGroup));
+                }
+              }}
+              disabled={projectGroup.tdei_project_group_id === selectedProjectGroup?.tdei_project_group_id}
+              className={
+                projectGroup.tdei_project_group_id === selectedProjectGroup?.tdei_project_group_id
+                  ? style.selectedProjectGroupItem
+                  : ""
+              }
+            >
+              {projectGroup.project_group_name}
+            </Dropdown.Item>
+          ))}
+
+          {projectGroups.length > 5 && (
+            <>
+              <Dropdown.Divider />
+              <Dropdown.Item
+                onClick={() => navigate("/projectGroupSwitch")}
+                className={style.seeAllOptions}
+              >
+                See all options
+              </Dropdown.Item>
+            </>
+          )}
         </Dropdown.Menu>
       </Dropdown>
     </div>
   );
+  
 };
 
 const CustomToggle = React.forwardRef(({ children, onClick }, ref) => (

--- a/tdei-ui/src/routes/Datasets/Datasets.js
+++ b/tdei-ui/src/routes/Datasets/Datasets.js
@@ -27,7 +27,7 @@ const Datasets = () => {
                   Here are the list of datasets available
               </div>
           </div>
-          {(isWritable || user.isAdmin) &&  
+          {isWritable &&  
           (<div>
               <Button onClick={handleUploadNav} className="tdei-primary-button">
                   Upload Dataset


### PR DESCRIPTION
## DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1749

## Changes Introduced  
- Limited the number of project groups displayed in the dropdown to **five**.  
- Added a **"See all options"** item at the end of the list if there are more than five project groups.  
- The **currently selected project group** (if within the first five) is highlighted and **disabled** to prevent re-selection.  


## Impacted Areas for Testing  
- Verify that only **five project groups** appear in the dropdown.  
- Ensure the **selected project group is highlighted** and non-clickable if it is among the first five.  
- Confirm that clicking **"See all options"** navigates to the **project group switch page**.  
- Ensured that when a project group is selected from the dropdown, it persists across page reloads and other tabs.

## Screenshots  
<img width="1470" alt="Screenshot 2025-03-06 at 6 13 50 PM" src="https://github.com/user-attachments/assets/152b7d4e-103c-4790-87a3-f974f939aa7e" />

---

## DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1748

## Changes Introduced  
- The **"Upload Dataset"** button is now hidden for users with the **admin role**.  
- Other roles (Data generators and POCs) will still see the button as expected.  


## Impacted Areas for Testing  
- Verify that the "Upload Dataset" button is hidden for users with the admin role.  
- Ensure that non-admin users (Data generators and POCs) can still see and interact with the button.  


## Screenshots  
<img width="1470" alt="Screenshot 2025-03-06 at 6 18 01 PM" src="https://github.com/user-attachments/assets/b567762e-c278-4479-a4fa-146232924b90" />


