### PR TITLE
Feature-bug-1760-Session Expired Error is shown even on fresh login & UI not updating on new refresh token

### DIFF
--- a/tdei-ui/src/services/axiosService.js
+++ b/tdei-ui/src/services/axiosService.js
@@ -110,7 +110,7 @@ axios.interceptors.response.use(
       //Removing local storage items so that when user refreshes or clicks on back button, user will be logged out
       //----------------------------
       localStorage.removeItem("accessToken");
-      localStorage.removeItem("refreshToken");
+      // localStorage.removeItem("refreshToken");
       localStorage.removeItem("selectedProjectGroup");
       if (originalRequest.session_timeout_login_request != undefined && originalRequest.session_timeout_login_request) {
         //----------------------------

--- a/tdei-ui/src/services/axiosService.js
+++ b/tdei-ui/src/services/axiosService.js
@@ -29,6 +29,8 @@ async function refreshRequest(originalRequest) {
     localStorage.setItem("accessToken", access_token);
     localStorage.setItem("refreshToken", refresh_token);
     console.log("Token refreshed successfully");
+    // Dispatch a global event to notify all listeners that the token has been refreshed.
+    window.dispatchEvent(new Event("tokenRefreshed"));
     // Return new access token to use it for retrying
     return access_token;
     // }


### PR DESCRIPTION
## **Bug Fix**  
### **DevBoard Task**  
[https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1760](https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1760)

### **Issue Summary**  
- When a user **visits the portal for the first time**, a **"Session expired"** error is displayed incorrectly.  
- This message should only appear when **both access token and refresh token are expired** and the user **refreshes or clicks the back button**.  
- In some rare cases, when an **access token expires**, the user gets a **401 error**, the **refresh token request succeeds**, but the **UI does not reflect the new token** and remains in an incorrect state.

### **Fix Implemented**  
- Ensured the "Session expired" message only appears when both tokens are expired and the user refreshes or clicks the back button.  
-  - Before: When the token was refreshed, the UI did not update, because React Query was still using old cached data.
    - Now: When the token refreshes, this event triggers an immediate refetch, ensuring the UI updates with fresh API data.

     Below is the corrected flow :

     1. User makes an API request → token is expired → 401 error is received.
     2. Interceptor calls refreshRequest() → token refresh succeeds.
     3. New token is stored → "tokenRefreshed" event is dispatched.
     4. React Query immediately invalidates cached data and refetches it.
     5. Original API request is retried with the latest token.
     6. UI updates with fresh data from React Query

---

## **Impacted Areas for Testing**  

### **1. Session Expiration Handling**  
| Test Case | Steps | Expected Behavior | Pass/Fail |  
|-----------|-------|------------------|-----------|  
| **First-time Portal Visit** | 1. Open portal in an incognito window <br> 2. Do not log in | No session expired message should be shown. | Pass|  
| **Expired Tokens & Page Refresh** | 1. Let both access & refresh tokens expire <br> 2. Refresh the page | "Session expired" message appears, and the user is redirected to login. | Pass |  
| **Expired Tokens & Back Button** | 1. Let both tokens expire <br> 2. Click the browser back button | "Session expired" message appears, and the user is redirected to login. | Pass |  

### **2. Token Refresh & UI Updates**  
| Test Case | Steps | Expected Behavior | Pass/Fail |  
|-----------|-------|------------------|-----------|  
| **Access Token Expired, Refresh Token Works** | 1. Let the access token expire <br> 2. Make an API call <br> 3. Verify a refresh request is triggered | API request retries with a new token, and UI updates properly. | Pass | 
 | **Both Access and Refresh Token Expired** | 1. Let both the tokens expire <br> 2. Make an API call <br> 3. Verify a refresh request is triggered. <br> 4. Refresh token also throws error and check the UI. | API request throws 401 error, and Re-login modal appears. | Pass |  
| **React Query Updates After Refresh** | 1. Let the access token expire <br> 2. Make an API call <br> 3. Verify `invalidateQueries()` is called after token refresh | UI reflects the updated API data without manual refresh. | Pass|  
| **Immediate API Calls After Token Refresh** | 1. Let the access token expire <br> 2. Make an API call immediately after refresh <br> 3. Verify correct token is used | The new access token is applied, and no additional 401 errors occur. | Pass |  


