### PR TITLE
Feature-task-1778-Custom Metadata JSON validation

### DIFF
--- a/tdei-ui/src/components/VerticalStepper/VerticalStepper.js
+++ b/tdei-ui/src/components/VerticalStepper/VerticalStepper.js
@@ -298,12 +298,19 @@ export default function VerticalStepper({ stepsData, onStepsComplete,currentStep
     // Validate schema_version based on service_type
     const serviceType = selectedData[0]?.service_type;
     const schemaVersion = dataset_detail.schema_version;
+    const custom_metadata = dataset_detail.custom_metadata;
     const schemaVersionMapping = {
       osw: "v0.2",
       flex: "v2.0",
       pathways: "v1.0",
     };
-
+    if (custom_metadata) {
+      try {
+        JSON.parse(custom_metadata);
+      } catch (e) {
+        return "Custom Metadata is not a valid JSON string.";
+      }
+    }
     if (schemaVersionMapping[serviceType] && schemaVersion !== schemaVersionMapping[serviceType]) {
       return `For service type "${serviceType}", Schema Version must be "${schemaVersionMapping[serviceType]}"`;
     }

--- a/tdei-ui/src/routes/CloneDataset/CloneDatasetStepper.js
+++ b/tdei-ui/src/routes/CloneDataset/CloneDatasetStepper.js
@@ -382,12 +382,19 @@ export default function CloneDatasetStepper({ stepsData, onStepsComplete, curren
     // Validate schema_version based on service_type
     const serviceType = selectedData[1].service_type;
     const schemaVersion = dataset_detail.schema_version;
+    const custom_metadata = dataset_detail.custom_metadata;
     const schemaVersionMapping = {
       osw: "v0.2",
       flex: "v2.0",
       pathways: "v1.0",
     };
-
+    if (custom_metadata) {
+      try {
+        JSON.parse(custom_metadata);
+      } catch (e) {
+        return "Custom Metadata is not a valid JSON string.";
+      }
+    }
     if (schemaVersionMapping[serviceType] && schemaVersion !== schemaVersionMapping[serviceType]) {
       return `For service type "${serviceType}", Schema Version must be "${schemaVersionMapping[serviceType]}"`;
     }

--- a/tdei-ui/src/routes/EditMetaData/EditMetaData.js
+++ b/tdei-ui/src/routes/EditMetaData/EditMetaData.js
@@ -267,6 +267,13 @@ export default function EditMetadata() {
         if (!validDataSources.includes(dataset_detail.data_source)) {
             return `Data Source must be one of: ${validDataSources.join(", ")}`;
         }
+        if (dataset_detail.custom_metadata) {
+            try {
+                JSON.parse(dataset_detail.custom_metadata);
+            } catch (e) {
+                return "Custom Metadata is not a valid JSON string.";
+            }
+        }
 
         // Validate schema_version based on service_type
         const serviceType = dataset.data_type;

--- a/tdei-ui/src/routes/UploadDataset/MetaDataForm/DatasetDetails.js
+++ b/tdei-ui/src/routes/UploadDataset/MetaDataForm/DatasetDetails.js
@@ -247,6 +247,9 @@ const DatasetDetails = ({dataType,isDatasetPublished = false, formData, updateFo
           </div>
           <div id="custom_metadata" className="section-style">
             <Form.Label>Custom Metadata</Form.Label>
+              <div className="tdei-hint-text">
+                Enter metadata as a valid JSON string. e.g., {'{"key": "value"}'}
+              </div>
             <div className="jsonContent">
               <Form.Control
                 as="textarea"


### PR DESCRIPTION
## DevBoard Task  
[https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1778](https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1778)

## Changes Introduced  
- Added helper text to the **Custom Metadata** field in the `DatasetDetails` form to indicate that the input must be a valid JSON string. Example JSON structure (`{"key": "value"}`) is shown as guidance for users.  
- Implemented validation logic to check if the `custom_metadata` field contains valid JSON when the form is submitted. An appropriate error is shown if the JSON is malformed.

## Impacted Areas for Testing  
- Verify that the **Custom Metadata** field displays the helper text: _"Enter metadata as a valid JSON string. e.g., {'{"key": "value"}'}"_  
- Enter valid and invalid JSON in the Custom Metadata field and try submitting the form.  
- Ensure an error appears on submit if the JSON is invalid, and that valid JSON allows submission. 
- Test same scenario wherever custom metadata field is present. Eg, Clone, Edit metadata, Upload dataset.  


## Screenshots  
<img width="1470" alt="Screenshot 2025-03-20 at 5 31 35 PM" src="https://github.com/user-attachments/assets/59d1fa6d-67f6-4167-83a5-390d0cef80af" />
