### PR TITLE
Hotfix Bug Fixes - API Key Error and Release Access issue for x_data_generator

### DIFF
--- a/tdei-ui/src/hooks/useIsDataTypeGenerator.js
+++ b/tdei-ui/src/hooks/useIsDataTypeGenerator.js
@@ -1,0 +1,8 @@
+import { useSelector } from "react-redux";
+import { getSelectedProjectGroup } from "../selectors";
+
+//Custom hook to check if the user has the "<data_type>_data_generator" role.
+export default function useIsDataTypeGenerator(data_type) {
+  const { roles = [] } = useSelector(getSelectedProjectGroup);
+  return roles.includes(`${data_type}_data_generator`);
+}

--- a/tdei-ui/src/routes/Datasets/DatasetsActions.js
+++ b/tdei-ui/src/routes/Datasets/DatasetsActions.js
@@ -14,6 +14,7 @@ import useIsDatasetsAccessible from '../../hooks/useIsDatasetsAccessible';
 import useIsOswGenerator from '../../hooks/useIsOswGenerator';
 import useIsMember from '../../hooks/roles/useIsMember';
 import { useAuth } from "../../hooks/useAuth";
+import useIsDataTypeGenerator from '../../hooks/useIsDataTypeGenerator';
 
 const DatasetsActions = ({ status, onAction, isReleasedDataset, data_type }) => {
   const { user } = useAuth();
@@ -21,11 +22,14 @@ const DatasetsActions = ({ status, onAction, isReleasedDataset, data_type }) => 
   const isMember = useIsMember();
   const isOswGenerator = useIsOswGenerator();
   const isDataGenerator = useIsDatasetsAccessible();
+  //check if user has "<data_type>_data_generator" role
+  const isDataTypeGenerator = useIsDataTypeGenerator(data_type);
 
   const canManageUser = isPocUser || user?.isAdmin;
   const canModifyDataset = isDataGenerator || user?.isAdmin;
   const canClone = isDataGenerator || user?.isAdmin || isMember;
   const canAddIncline = isPocUser || user?.isAdmin || isOswGenerator;
+  const canPublish = isPocUser || user?.isAdmin || isDataTypeGenerator;
   
   //Role based available actions
   const actions = [
@@ -37,7 +41,8 @@ const DatasetsActions = ({ status, onAction, isReleasedDataset, data_type }) => 
       condition: true,
     },
     // "Release" is available for non-released datasets if the user can manage the dataset and the status isn't "Publish"
-    !isReleasedDataset && canManageUser && status !== "Publish" && {
+    // User can release if they're a POC, an admin, or a <data_type>_data_generator
+    !isReleasedDataset && canPublish && status !== "Publish" && {
       key: "release",
       label: "Release",
       icon: releaseIcon,

--- a/tdei-ui/src/services/apiServices.js
+++ b/tdei-ui/src/services/apiServices.js
@@ -80,7 +80,8 @@ export async function getRoles() {
 
 export async function getApiKey({ queryKey }) {
   const [, userId] = queryKey;
-  const res = await axios.get(`${url}/user-profile?user_name=${userId}`);
+  const encodedEmail = encodeURIComponent(userId); 
+  const res = await axios.get(`${url}/user-profile?user_name=${encodedEmail}`);
   return res.data;
 }
 export async function getProjectGroupRoles(userId, pageParam = 1, queryText = "") {


### PR DESCRIPTION
### DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1787

### Issue Summary  
- Users with roles like `osw_data_generator`, `flex_data_generator`, etc. could not see the **Release** option in the UI for datasets of their respective `data_type`.
- The existing logic for `canPublish` only allowed POC users or Admins to see the "Release" option.
- As a result, even valid generator roles could not release their datasets.

### Fix Implemented  
- Introduced a new hook: `useIsDataTypeGenerator(data_type)`
  - This hook checks if the user has a role matching the pattern `<data_type>_data_generator`.
  - It pulls role info from the selected project group.
- Updated the `canPublish` logic in `DatasetsActions.js`:
```
const canPublish = isPocUser || user?.isAdmin || isDataTypeGenerator;
```
### Impacted Areas for Testing
## ✅ Test Cases for `DatasetsActions`

| Role Combination           | Dataset data_type | isReleasedDataset | Expected Available Actions                                                        |
|----------------------------|------------------|--------------------|----------------------------------------------------------------------------------|
| Admin                      | osw              | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Add Inclination, Clone, Download |
| Admin                      | osw              | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| Admin                      | pathways         | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Clone, Download         |
| Admin                      | pathways         | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| Admin                      | flex             | FALSE              | Release, Deactivate, Edit Metadata, Clone, Download                             |
| Admin                      | flex             | TRUE               | Edit Metadata, Add Inclination, Clone, Download                                 |
| POC                        | osw              | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Add Inclination, Clone, Download |
| POC                        | osw              | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| POC                        | pathways         | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Clone, Download         |
| POC                        | pathways         | TRUE               | Open in Workspaces, Edit Metadata, Add Inclination, Clone, Download             |
| POC                        | flex             | FALSE              | Release, Deactivate, Edit Metadata, Clone, Download                             |
| POC                        | flex             | TRUE               | Edit Metadata, Add Inclination, Clone, Download                                 |
| flex_data_generator        | osw              | FALSE              | Open in Workspaces, Edit Metadata, Clone, Download                              |
| flex_data_generator        | osw              | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| flex_data_generator        | pathways         | FALSE              | Open in Workspaces, Edit Metadata, Add Inclination, Clone, Download             |
| flex_data_generator        | pathways         | TRUE               | Open in Workspaces, Edit Metadata, Add Inclination, Clone, Download             |
| flex_data_generator        | flex             | FALSE              | Release, Deactivate, Edit Metadata, Clone, Download                             |
| flex_data_generator        | flex             | TRUE               | Edit Metadata, Clone, Download                                                  |
| osw_data_generator         | osw              | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Add Inclination, Clone, Download |
| osw_data_generator         | osw              | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| osw_data_generator         | pathways         | FALSE              | Open in Workspaces, Edit Metadata, Clone, Download                              |
| osw_data_generator         | pathways         | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| osw_data_generator         | flex             | FALSE              | Edit Metadata, Clone, Download                                                  |
| osw_data_generator         | flex             | TRUE               | Edit Metadata, Clone, Download                                                  |
| pathways_data_generator    | osw              | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Clone, Download         |
| pathways_data_generator    | osw              | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| pathways_data_generator    | pathways         | FALSE              | Open in Workspaces, Edit Metadata, Clone, Download                              |
| pathways_data_generator    | pathways         | TRUE               | Open in Workspaces, Release, Deactivate, Edit Metadata, Clone, Download         |
| pathways_data_generator    | flex             | FALSE              | Release, Edit Metadata, Clone, Download                                         |
| pathways_data_generator    | flex             | TRUE               | Edit Metadata, Clone, Download                                                  |
| Member                     | osw              | FALSE              | Open in Workspaces, Clone, Download                                             |
| Member                     | osw              | TRUE               | Open in Workspaces, Clone, Download                                             |
| Member                     | pathways         | FALSE              | Open in Workspaces, Clone, Download                                             |
| Member                     | pathways         | TRUE               | Open in Workspaces, Clone, Download                                             |
| Member                     | flex             | FALSE              | Open in Workspaces, Clone, Download                                             |
| Member                     | flex             | TRUE               | Open in Workspaces, Clone, Download                                             |

---

### DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1789

### Issue Summary  
API key and user profile details were not being fetched when the email contained special characters such as +.
The frontend was sending a raw query string without URL encoding the email, which caused the + to be interpreted as a space on the backend.
- Example of failing request :
```
https://portal-api-stage.tdei.us/api/v1/user-profile?user_name=nareshd+dev@gaussiansolutions.com
```
- The correct and working request should be URL encoded :
```
https://portal-api-stage.tdei.us/api/v1/user-profile?user_name=nareshd%2Bdev%40gaussiansolutions.com

```
### Fix Implemented  
- Used encodeURIComponent(email) on the frontend before making the GET request
```
const encodedEmail = encodeURIComponent(email);
axios.get(`/api/v1/user-profile?user_name=${encodedEmail}`);
```
- This ensures special characters like +, @, and others are properly escaped in the URL.

### Impacted Areas for Testing

- User profile and API key visibility via GET requests to /user-profile endpoint.
- Email variations tested:
      - sureshd+dev@gaussiansolutions.com
       - mahesh_badmanji@yahoo.com
        - lara.williams@gmail.com
