### PR TITLE
Feature-Bug-1787 -API Key Error and Release Access issue for x_data_generator & Bug-1774

### DIFF
--- a/tdei-ui/src/components/AuthProvider/AuthProvider.js
+++ b/tdei-ui/src/components/AuthProvider/AuthProvider.js
@@ -119,8 +119,16 @@ const AuthProvider = ({ children }) => {
   // stay synchronized whenever a forced refresh is triggered from elsewhere.
   React.useEffect(() => {
     function handleStorageEvent(event) {
-      if (event.key === "forceRefresh") {
-        window.location.reload();
+      switch (event.key) {
+        case "forceRefresh":
+          window.location.reload();
+          break;
+        case "forceLogout":
+          window.location.replace("/login");
+          break;
+        default:
+          // do nothing
+          break;
       }
     }
     window.addEventListener("storage", handleStorageEvent);

--- a/tdei-ui/src/components/Header/Header.js
+++ b/tdei-ui/src/components/Header/Header.js
@@ -20,11 +20,17 @@ const Header = () => {
   const [showModal, setShowModal] = React.useState(false);
 
   const handleLogout = () => {
+    //Broadcast a 'forceLogout' event to other tabs
+    localStorage.setItem("forceLogout", Date.now().toString());
+    setTimeout(() => {
+      localStorage.removeItem("forceLogout");
+    }, 0);
+    dispatch(clear());
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
-    dispatch(clear());
     window.location.reload();
   };
+  
   const handleResetPassword = () => {
     setShowModal(true);
   };

--- a/tdei-ui/src/components/ProjectAutocomplete/ProjectAutocomplete.js
+++ b/tdei-ui/src/components/ProjectAutocomplete/ProjectAutocomplete.js
@@ -75,7 +75,6 @@ const ProjectAutocomplete = ({ selectedProjectGroupId, projectSearchText, setPro
     setProjectSearchText(projectGroup.project_group_name)
     setShowDropdown(false);
     onSelectProjectGroup(projectGroup.tdei_project_group_id);
-    console.log("Selected Project Group ID:", projectGroup.tdei_project_group_id); 
   };
 
   const handleClickOutside = useCallback(

--- a/tdei-ui/src/components/ReLoginModal/ReLoginModal.js
+++ b/tdei-ui/src/components/ReLoginModal/ReLoginModal.js
@@ -19,9 +19,14 @@ const ReLoginModal = ({ open, onClose, onReLogin, email }) => {
     setShowPassword(!showPassword);
   };
   const handleLogout = () => {
+    //Broadcast a 'forceLogout' event to other tabs
+    localStorage.setItem("forceLogout", Date.now().toString());
+    setTimeout(() => {
+      localStorage.removeItem("forceLogout");
+    }, 0);
+    dispatch(clear());
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
-    dispatch(clear()); 
     window.location.reload();
   };
 

--- a/tdei-ui/src/hooks/useIsDataTypeGenerator.js
+++ b/tdei-ui/src/hooks/useIsDataTypeGenerator.js
@@ -1,0 +1,8 @@
+import { useSelector } from "react-redux";
+import { getSelectedProjectGroup } from "../selectors";
+
+//Custom hook to check if the user has the "<data_type>_data_generator" role.
+export default function useIsDataTypeGenerator(data_type) {
+  const { roles = [] } = useSelector(getSelectedProjectGroup);
+  return roles.includes(`${data_type}_data_generator`);
+}

--- a/tdei-ui/src/routes/Datasets/DatasetsActions.js
+++ b/tdei-ui/src/routes/Datasets/DatasetsActions.js
@@ -14,6 +14,7 @@ import useIsDatasetsAccessible from '../../hooks/useIsDatasetsAccessible';
 import useIsOswGenerator from '../../hooks/useIsOswGenerator';
 import useIsMember from '../../hooks/roles/useIsMember';
 import { useAuth } from "../../hooks/useAuth";
+import useIsDataTypeGenerator from '../../hooks/useIsDataTypeGenerator';
 
 const DatasetsActions = ({ status, onAction, isReleasedDataset, data_type }) => {
   const { user } = useAuth();
@@ -21,11 +22,13 @@ const DatasetsActions = ({ status, onAction, isReleasedDataset, data_type }) => 
   const isMember = useIsMember();
   const isOswGenerator = useIsOswGenerator();
   const isDataGenerator = useIsDatasetsAccessible();
-
+  //check if user has "<data_type>_data_generator" role
+  const isDataTypeGenerator = useIsDataTypeGenerator(data_type);
   const canManageUser = isPocUser || user?.isAdmin;
   const canModifyDataset = isDataGenerator || user?.isAdmin;
   const canClone = isDataGenerator || user?.isAdmin || isMember;
   const canAddIncline = isPocUser || user?.isAdmin || isOswGenerator;
+  const canPublish = isPocUser || user?.isAdmin || isDataTypeGenerator;
   
   //Role based available actions
   const actions = [
@@ -37,7 +40,7 @@ const DatasetsActions = ({ status, onAction, isReleasedDataset, data_type }) => 
       condition: true,
     },
     // "Release" is available for non-released datasets if the user can manage the dataset and the status isn't "Publish"
-    !isReleasedDataset && canManageUser && status !== "Publish" && {
+    !isReleasedDataset && canPublish && status !== "Publish" && {
       key: "release",
       label: "Release",
       icon: releaseIcon,

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -98,9 +98,6 @@ const MyDatasets = () => {
         }
     }, [data]);
 
-    useEffect(() => {
-        console.log("Selected Project Group ID in MyDatasets:", selectedProjectGroupId);
-    }, [selectedProjectGroupId]);
 
     const handleSelectedDataType = (value) => {
         setDataType(value.value);


### PR DESCRIPTION
### DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1787

### Issue Summary  
- Users with roles like `osw_data_generator`, `flex_data_generator`, etc. could not see the **Release** option in the UI for datasets of their respective `data_type`.
- The existing logic for `canPublish` only allowed POC users or Admins to see the "Release" option.
- As a result, even valid generator roles could not release their datasets.

### Fix Implemented  
- Introduced a new hook: `useIsDataTypeGenerator(data_type)`
  - This hook checks if the user has a role matching the pattern `<data_type>_data_generator`.
  - It pulls role info from the selected project group.
- Updated the `canPublish` logic in `DatasetsActions.js`:
```
const canPublish = isPocUser || user?.isAdmin || isDataTypeGenerator;
```
### Impacted Areas for Testing
## Test Cases for `DatasetsActions`

| Role Combination           | Dataset data_type | isReleasedDataset | Expected Available Actions                                                        |
|----------------------------|------------------|--------------------|----------------------------------------------------------------------------------|
| Admin                      | osw              | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Add Inclination, Clone, Download |
| Admin                      | osw              | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| Admin                      | pathways         | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Clone, Download         |
| Admin                      | pathways         | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| Admin                      | flex             | FALSE              | Release, Deactivate, Edit Metadata, Clone, Download                             |
| Admin                      | flex             | TRUE               | Edit Metadata, Add Inclination, Clone, Download                                 |
| POC                        | osw              | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Add Inclination, Clone, Download |
| POC                        | osw              | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| POC                        | pathways         | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Clone, Download         |
| POC                        | pathways         | TRUE               | Open in Workspaces, Edit Metadata, Add Inclination, Clone, Download             |
| POC                        | flex             | FALSE              | Release, Deactivate, Edit Metadata, Clone, Download                             |
| POC                        | flex             | TRUE               | Edit Metadata, Add Inclination, Clone, Download                                 |
| flex_data_generator        | osw              | FALSE              | Open in Workspaces, Edit Metadata, Clone, Download                              |
| flex_data_generator        | osw              | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| flex_data_generator        | pathways         | FALSE              | Open in Workspaces, Edit Metadata, Add Inclination, Clone, Download             |
| flex_data_generator        | pathways         | TRUE               | Open in Workspaces, Edit Metadata, Add Inclination, Clone, Download             |
| flex_data_generator        | flex             | FALSE              | Release, Deactivate, Edit Metadata, Clone, Download                             |
| flex_data_generator        | flex             | TRUE               | Edit Metadata, Clone, Download                                                  |
| osw_data_generator         | osw              | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Add Inclination, Clone, Download |
| osw_data_generator         | osw              | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| osw_data_generator         | pathways         | FALSE              | Open in Workspaces, Edit Metadata, Clone, Download                              |
| osw_data_generator         | pathways         | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| osw_data_generator         | flex             | FALSE              | Edit Metadata, Clone, Download                                                  |
| osw_data_generator         | flex             | TRUE               | Edit Metadata, Clone, Download                                                  |
| pathways_data_generator    | osw              | FALSE              | Open in Workspaces, Release, Deactivate, Edit Metadata, Clone, Download         |
| pathways_data_generator    | osw              | TRUE               | Open in Workspaces, Edit Metadata, Clone, Download                              |
| pathways_data_generator    | pathways         | FALSE              | Open in Workspaces, Edit Metadata, Clone, Download                              |
| pathways_data_generator    | pathways         | TRUE               | Open in Workspaces, Release, Deactivate, Edit Metadata, Clone, Download         |
| pathways_data_generator    | flex             | FALSE              | Release, Edit Metadata, Clone, Download                                         |
| pathways_data_generator    | flex             | TRUE               | Edit Metadata, Clone, Download                                                  |
| Member                     | osw              | FALSE              | Open in Workspaces, Clone, Download                                             |
| Member                     | osw              | TRUE               | Open in Workspaces, Clone, Download                                             |
| Member                     | pathways         | FALSE              | Open in Workspaces, Clone, Download                                             |
| Member                     | pathways         | TRUE               | Open in Workspaces, Clone, Download                                             |
| Member                     | flex             | FALSE              | Open in Workspaces, Clone, Download                                             |
| Member                     | flex             | TRUE               | Open in Workspaces, Clone, Download                                             |

---

## **Bug Fix**  
### **DevBoard Task**  
[https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1774](https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1774)

### **Issue Summary**  
- When multiple portals (dev portal, stage portal) or multiple browser tabs of the same app are open and a new user logs in on one tab, the **current selected project group** gets overwritten in the other tab.  

Fix for above case has been implemented in PR #202 , but this should be handled for logout as well.

### **Fix Implemented**  

Added another event to logout the user on logout event to syncronise all the tabs.

---

## **Impacted Areas for Testing**  
- **Simultaneous Logins**:  
  1. Open dev portal in one tab, duplicate portal in another tab.  
  2. Logout from one tab and check the other.  
  3. Verify that the old tab also shows login page.  
  


