### PR TITLE
Feature-task-2048-OSW Data File Limit Change

### DIFF
--- a/tdei-ui/src/components/DropZone/Dropzone.js
+++ b/tdei-ui/src/components/DropZone/Dropzone.js
@@ -10,10 +10,11 @@ import { useDispatch } from "react-redux";
 import JSZip from "jszip";
 
 // Functional component Dropzone
-function Dropzone({ onDrop, accept, format, selectedFile }) {
+function Dropzone({ onDrop, accept, format, maxSizeMB, selectedFile }) {
   const dispatch = useDispatch();
   const [myFiles, setMyFiles] = useState([]);
-  const MAX_SIZE_MB = 1024;
+  const DEFAULT_SIZE_MB   = 1024;
+  const ALLOWED_SIZE_MB   = maxSizeMB ?? DEFAULT_SIZE_MB;
 
   useEffect(() => {
     if (selectedFile instanceof File) {
@@ -27,11 +28,10 @@ function Dropzone({ onDrop, accept, format, selectedFile }) {
     accept,
     onDrop: async (acceptedFiles) => {
       const totalSizeInMB = await calculateTotalUncompressedSize(acceptedFiles);
-      if (totalSizeInMB > MAX_SIZE_MB) {
+      if (totalSizeInMB > ALLOWED_SIZE_MB) {
         dispatch(
-          show({
-            message:
-              "The total size of dataset files in zip exceeds 1 GB upload limit.",
+         show({
+            message: `The total size of dataset files exceeds ${ALLOWED_SIZE_MB / 1024} GB upload limit.`,
             type: "danger",
           })
         );
@@ -66,7 +66,7 @@ function Dropzone({ onDrop, accept, format, selectedFile }) {
     try {
       zip = await jszip.loadAsync(fileOrBlob);
     } catch (e) {
-      throw new Error("Error loading zip file");
+      return fileOrBlob.size;
     }
     let totalSize = 0;
     const entries = Object.values(zip.files);

--- a/tdei-ui/src/routes/Jobs/CreateJob.js
+++ b/tdei-ui/src/routes/Jobs/CreateJob.js
@@ -139,13 +139,6 @@ const CreateJobService = () => {
     const twoGBJobTypes = [
         'osw-validate',
         'osw-convert',
-        'confidence',
-        'quality-metric',
-        'dataset-bbox',
-        'dataset-tag-road',
-        'quality-metric-tag',
-        'spatial-join',
-        'dataset-union'
     ];
     const dropzoneMaxSizeMB =
         jobType && twoGBJobTypes.includes(jobType.value)

--- a/tdei-ui/src/routes/Jobs/CreateJob.js
+++ b/tdei-ui/src/routes/Jobs/CreateJob.js
@@ -135,7 +135,22 @@ const CreateJobService = () => {
 
     const filteredJobTypeOptions = jobTypeOptions.filter(option => 
         !(option.value === "dataset-tag-road" && (!isDataAccessible && !user?.isAdmin))
-    );    
+    );  
+    const twoGBJobTypes = [
+        'osw-validate',
+        'osw-convert',
+        'confidence',
+        'quality-metric',
+        'dataset-bbox',
+        'dataset-tag-road',
+        'quality-metric-tag',
+        'spatial-join',
+        'dataset-union'
+    ];
+    const dropzoneMaxSizeMB =
+        jobType && twoGBJobTypes.includes(jobType.value)
+            ? 2048
+            : 1024;  
 
     // Updates the algorithm configuration state based on input from the QualityMetricAlgo component.
     const handleAlgorithmUpdate = (updatedConfig) => {
@@ -590,6 +605,7 @@ const CreateJobService = () => {
                     accept={getAcceptedFileTypes()}
                     format={getFileFormat()}
                     selectedFile={selectedFile}
+                    maxSizeMB={dropzoneMaxSizeMB}
                 />
                 <div className="d-flex align-items-start mt-2">
                     <Form.Text id="passwordHelpBlock" className={style.description}>

--- a/tdei-ui/src/routes/UploadDataset/DataFile.js
+++ b/tdei-ui/src/routes/UploadDataset/DataFile.js
@@ -8,7 +8,7 @@ import style from './UploadDataset.module.css';
 import { Form } from "react-bootstrap";
 
 // Functional component DataFile
-const DataFile = ({ selectedData = {}, onSelectedFileChange }) => {
+const DataFile = ({ selectedData = {}, onSelectedFileChange, dataType }) => {
   const [derivedDatasetId, setDerivedDatasetId] = useState('');
 
   useEffect(() => {
@@ -16,6 +16,11 @@ const DataFile = ({ selectedData = {}, onSelectedFileChange }) => {
       setDerivedDatasetId(selectedData.derived_from_dataset_id);
     }
   }, [selectedData]);
+
+  const TWO_GB_TYPES = ['osw'];
+  const dropzoneMaxSizeMB = TWO_GB_TYPES.includes(dataType)
+    ? 2048
+    : undefined;
 
   // Function to handle file drop
   const onDrop = (files) => {
@@ -69,7 +74,7 @@ const DataFile = ({ selectedData = {}, onSelectedFileChange }) => {
       }}>
         Attach data file<span style={{ color: 'red' }}> *</span>
       </Typography>
-      <Dropzone onDrop={onDrop} accept={{ 'application/zip': ['.zip'] }} format={".zip"} selectedFile={selectedData.file} />
+      <Dropzone onDrop={onDrop} accept={{ 'application/zip': ['.zip'] }} format={".zip"} selectedFile={selectedData.file}  maxSizeMB={dropzoneMaxSizeMB} />
     </div>
   );
 };


### PR DESCRIPTION
## DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2048

### Changes Introduced
- Upload limit updated from 1 GB to 2 GB for:
  - `osw-validate`
  - `osw-convert`
  - OSW dataset upload

### Impacted Areas for Testing
- Verify upload with datasets ≤ 2 GB for the above operations  
- Verify upload with datasets > 2 GB for the above operations to ensure the new limit is enforced  

#### Screenshots
- OSW Dataset Upload
<img width="1470" alt="Screenshot 2025-06-11 at 11 13 54 AM" src="https://github.com/user-attachments/assets/68f1a8ba-c126-4c04-917f-c8f612188979" />
- Flex Dataset Upload
<img width="1470" alt="Screenshot 2025-06-11 at 11 14 06 AM" src="https://github.com/user-attachments/assets/f4322b0b-9465-47ac-b4d0-354c89385447" />
<img width="1470" alt="Screenshot 2025-06-11 at 11 17 45 AM" src="https://github.com/user-attachments/assets/3fea7308-eb23-446c-b430-a18b6af4ff59" />
<img width="1470" alt="Screenshot 2025-06-11 at 11 17 55 AM" src="https://github.com/user-attachments/assets/bec6a96c-c4f5-4070-bcf4-3cac06a02108" />

