### PR TITLE
Bug-2066 : Wrong job Id search shows improper error

### DIFF
--- a/tdei-ui/src/hooks/jobs/useGetJobs.js
+++ b/tdei-ui/src/hooks/jobs/useGetJobs.js
@@ -9,7 +9,7 @@ function useGetJobs(isAdmin, job_id = "", job_type = "", status = "", show = "")
     const { tdei_project_group_id } = useSelector(getSelectedProjectGroup);
     const [refreshKey, setRefreshKey] = useState(0); // for refreshing data
 
-    const { data, isError, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery(
+    const { data, isError,error, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery(
         [GET_JOBS, tdei_project_group_id, job_id, job_type, status, show, refreshKey],
         ({ queryKey, pageParam = 1 }) => {
             return getJobs(queryKey[1], pageParam, isAdmin, queryKey[2], queryKey[3], queryKey[4], queryKey[5]);
@@ -29,7 +29,7 @@ function useGetJobs(isAdmin, job_id = "", job_type = "", status = "", show = "")
     const refreshData = () => {
         setRefreshKey((prevKey) => prevKey + 1);
     };
-    return { data, isError, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading, refreshData };
+    return { data, isError, error, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading, refreshData };
 }
 
 export default useGetJobs;

--- a/tdei-ui/src/routes/Jobs/Jobs.js
+++ b/tdei-ui/src/routes/Jobs/Jobs.js
@@ -31,7 +31,7 @@ const Jobs = () => {
     const isAdmin = user && user.isAdmin;
     const isMember = useIsMember();
     const [sortedData, setSortedData] = useState([]);
-
+    const [jobError, setJobError] = useState('');
 
     // Options for job type dropdown
     const jobTypeOptions = [
@@ -100,6 +100,7 @@ const Jobs = () => {
     const {
         data = [],
         isError,
+        error,
         hasNextPage,
         fetchNextPage,
         isFetchingNextPage,
@@ -120,6 +121,13 @@ const Jobs = () => {
             setSortedData(sorted);
         }
     }, [data]);
+
+    useEffect(() => {
+        if (isError && (error?.response?.status === 404 || error?.response?.status === 400)) {
+          setSortedData([]);
+          setJobError(error.response.data)
+        }
+      }, [isError, error]);
 
     const handleJobTypeSelect = (value) => {
         setJobType(value);
@@ -299,17 +307,17 @@ const Jobs = () => {
                         sortedData.map((list, index) => (
                             <JobListItem jobItem={list} key={list.job_id} />
                         ))
-                    ) : (
+                    ): <div></div>}
+                    {isError && (error?.response?.status === 404 || error?.response?.status === 400) && (
                         <div className="d-flex align-items-center mt-2">
                             <img
                                 src={iconNoData}
                                 alt="no-data-icon"
                                 width="20"
                             />
-                            <div className={style.noDataText}>No Jobs Found..!</div>
+                            <div className={style.noDataText}>{jobError}</div>
                         </div>
                     )}
-                    {isError ? " Error loading project group list" : null}
                     {hasNextPage && !isLoading && (
                         <Button
                             className="tdei-primary-button"


### PR DESCRIPTION
## Bug Fix  
### DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2066  

### Issue Summary  
In job list page, when we enter a job ID which is not in the system, the API returns a 404. On the client side we need to show an empty result.  
Right now the user sees the generic error “Error loading project group list.”  

---
### Fix Implemented  
- Front end now treats a 404 or 400 or 500 on search as “no results”:  
  - Clears the job list  
  - Shows the either the exact error received from backend or empty results list.
---
### Impacted Areas for Testing  
- **Simulate 404 response**  
  - Enter a valid Job ID which doesnt exist in the system
  - Expect: job list clears, api error “Job with 124241 doesn't exist in the system!” is shown

- **Simulate 500 network error**  
  - Stub the GET-jobs API to return HTTP 500 
  - Expect: “Error loading jobs” is shown  

- **Simulate 400 response**  
  - Enter a random ID that isnt valid (e.g. `FOO123`)  
  - Expect: list area is empty, api error “Invalid Job Id” is displayed.

- **Search existing Job ID**  
  - Enter a valid Job ID  
  - Expect: matching job(s) appear, no “No Jobs Found” UI  

- **Clear search input**  
  - Delete all text from the search box  
  - Expect: full paginated list of jobs repopulates  

- **Refresh button after 404**  
  - With a non-existent ID entered, click the refresh icon  
  - Expect: still shows “Job with #random-id doesn't exist in the system!” 

---
### Screenshots 


<img width="1470" alt="Screenshot 2025-06-26 at 5 42 38 PM" src="https://github.com/user-attachments/assets/f19b42e4-fa0c-4562-8a53-d891f42b42f8" />
<img width="1470" alt="Screenshot 2025-06-26 at 5 43 02 PM" src="https://github.com/user-attachments/assets/988ec9ed-976e-4b54-9c64-4f521ba7d51a" />
<img width="1470" alt="Screenshot 2025-06-26 at 5 43 16 PM" src="https://github.com/user-attachments/assets/70cc1943-3f15-4ab5-b575-523bf904afe4" />
<img width="1470" alt="Screenshot 2025-06-26 at 5 43 36 PM" src="https://github.com/user-attachments/assets/08fda5e0-390e-4e90-b051-b28331ab1623" />




