### PR TITLE
Bug-2066 : Wrong job Id Error Added missed out cases

### DIFF
--- a/tdei-ui/src/routes/Jobs/Jobs.js
+++ b/tdei-ui/src/routes/Jobs/Jobs.js
@@ -123,7 +123,7 @@ const Jobs = () => {
     }, [data]);
 
     useEffect(() => {
-        if (isError && (error?.response?.status === 404 || error?.response?.status === 400)) {
+        if (isError && (error?.response?.status === 404 || error?.response?.status === 400) || error?.response?.status === 500) {
           setSortedData([]);
           setJobError(error.response.data)
         }
@@ -316,6 +316,16 @@ const Jobs = () => {
                                 width="20"
                             />
                             <div className={style.noDataText}>{jobError}</div>
+                        </div>
+                    )}  
+                    {isError && error?.response?.status === 500 && (
+                        <div className="d-flex align-items-center mt-2">
+                            <img
+                                src={iconNoData}
+                                alt="no-data-icon"
+                                width="20"
+                            />
+                            <div className={style.noDataText}>Error Loading Jobs!</div>
                         </div>
                     )}
                     {hasNextPage && !isLoading && (

--- a/tdei-ui/src/routes/Jobs/Jobs.module.css
+++ b/tdei-ui/src/routes/Jobs/Jobs.module.css
@@ -573,4 +573,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.noDataText {
+  font-size: 14px;
+  color: var(--secondary-color);
+  margin-left: 5px;
+}
 


### PR DESCRIPTION
## Bug Fix  
### DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2066  

### Issue Summary  
In job list page, when we enter a job ID which is not in the system, the API returns a 404. On the client side we need to show an empty result.  
Right now the user sees the generic error “Error loading project group list.”  

---
### Fix Implemented  
- **[NEW] Added missing condition** to handle 500 errors in:
  ```ts
  if (
    isError && (
      error?.response?.status === 404 ||
      error?.response?.status === 400 ||
      error?.response?.status === 500
    )
  )


