### PR TITLE
Bug-2113-Sort by created on & Bug-2112-Rename Dataset BBox

### DIFF
--- a/tdei-ui/src/components/JobListItem/JobListItem.js
+++ b/tdei-ui/src/components/JobListItem/JobListItem.js
@@ -20,6 +20,10 @@ const JobListItem = ({ jobItem }) => {
   const [eventKey, setEventKey] = useState("");
   const [showInputDescModal, setInputDescModal] = useState(false);
 
+  const JOB_TYPE_LABELS = {
+    "Dataset-BBox": "Filter Dataset By BBox",
+  };
+
   const handleToast = () => {
     setOpen(true);
   };
@@ -142,11 +146,12 @@ const JobListItem = ({ jobItem }) => {
   if (error) {
     console.log(error);
   }
+  const displayJobType = JOB_TYPE_LABELS[jobItem.job_type] ?? jobItem.job_type;
 
   return (
     <div className={style.gridContainer} key={jobItem.tdei_project_group_id}>
       <div className={style.content} tabIndex={0}>
-        {jobItem.job_type}
+        {displayJobType}
       </div>
       <div className={style.content} tabIndex={1}>
         Job Id: <span className={style.downloadLink}

--- a/tdei-ui/src/routes/Jobs/CreateJob.js
+++ b/tdei-ui/src/routes/Jobs/CreateJob.js
@@ -28,7 +28,7 @@ const jobTypeOptions = [
     { value: 'osw-convert', label: 'OSW - Convert' },
     { value: 'confidence', label: 'Confidence Calculation' },
     { value: 'quality-metric', label: 'Quality Metric IXN Calculation' },
-    { value: 'dataset-bbox', label: 'Dataset BBox' },
+    { value: 'dataset-bbox', label: 'Filter Dataset By BBox' },
     { value: 'dataset-tag-road', label: 'Dataset Tag Road' },
     { value: 'quality-metric-tag', label: 'Quality Metric Tag' },
     { value: 'spatial-join', label: 'Spatial Join' },

--- a/tdei-ui/src/routes/Jobs/Jobs.js
+++ b/tdei-ui/src/routes/Jobs/Jobs.js
@@ -73,18 +73,23 @@ const Jobs = () => {
         const direction = sortConfig.key === key && sortConfig.direction === 'ascending' ? 'descending' : 'ascending';
     
         const sorted = [...sortedData].sort((a, b) => {
-            const aValue = 
-                key === 'job_type' ? a.job_type :
-                key === 'job_id' ? a.job_id :
-                key === 'status' ? a.status :
-                a.requested_by;
-    
-            const bValue = 
-                key === 'job_type' ? b.job_type :
-                key === 'job_id' ? b.job_id :
-                key === 'status' ? b.status :
-                b.requested_by;
-    
+            let aValue, bValue;
+            if (key === 'job_type') {
+                aValue = a.job_type;
+                bValue = b.job_type;
+            } else if (key === 'job_id') {
+                aValue = Number(a.job_id);
+                bValue = Number(b.job_id);
+            } else if (key === 'status') {
+                aValue = a.status;
+                bValue = b.status;
+            } else if (key === 'created_at') {
+                aValue = new Date(a.created_at);
+                bValue = new Date(b.created_at);
+            } else {
+                aValue = a.requested_by;
+                bValue = b.requested_by;
+            }
             if (typeof aValue === 'string' && typeof bValue === 'string') {
                 return direction === 'ascending' 
                     ? aValue.localeCompare(bValue)

--- a/tdei-ui/src/routes/Jobs/Jobs.js
+++ b/tdei-ui/src/routes/Jobs/Jobs.js
@@ -38,7 +38,7 @@ const Jobs = () => {
         { value: '', label: 'All' },
         { value: 'Clone-Dataset', label: 'Clone Dataset' },
         { value: 'Confidence-Calculate', label: 'Confidence - Calculate' },
-        { value: 'Dataset-BBox', label: 'Dataset BBox' },
+        { value: 'Dataset-BBox', label: 'Filter Dataset By BBox' },
         { value: 'Dataset-Incline-Tag', label: 'Dataset Incline Tag' },
         { value: 'Dataset-Publish', label: 'Dataset Publish' },
         { value: 'Dataset-Reformat', label: 'Dataset Reformat' },

--- a/tdei-ui/src/routes/Jobs/Jobs.module.css
+++ b/tdei-ui/src/routes/Jobs/Jobs.module.css
@@ -57,6 +57,12 @@
   margin-bottom: 15px;
   font-size: 14px;
 }
+.gridContainer > .content {
+  min-width: 0;
+  white-space: normal;
+  word-break: break-word;    
+  overflow-wrap: anywhere;
+}
 
 .name {
   font-size: 16px;


### PR DESCRIPTION
## Bug Fix  
### DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2113 

### Issue Summary  
1) Login to TDEI 
2) Go to Jobs
3) Click on the "Created On" column
4) Results do not resort. Clicking on it again does not invert the result.

---

### Fix Implemented  
- Date sort for Created On
- Unified sortData 
  - Expanded `sortData()` to handle `job_type`, `job_id`, `status`, `created_at`, and `requested_by`.  
  - Toggled sort direction on repeated clicks.  

---

### Impacted Areas for Testing
- Sort by Job Type 
  1. Click “Job Type” header → list sorts A->Z  
  2. Click again -> Z->A  

- Sort by Job ID
  1. Click “Job ID” header -> numeric ascending
  2. Click again -> numeric descending  

- Sort by Status  
  1. Click “Status” -> alphabetical ascending   
  2. Click again → reverse order  

- Sort by Created On  
  1. Click “Created On” -> chronological ascending (oldest -> newest)  
  2. Click again -> newest -> oldest  

- Sort by Submitted By  
  1. Click “Submitted By” -> alphabetical ascending  
  2. Click again -> descending  

- Direction toggle  
  - Verify that each column header flips direction on repeat clicks.  
  
 ---
 
 ### Screenshot:
 
<img width="1470" height="956" alt="Screenshot 2025-07-17 at 1 23 24 PM" src="https://github.com/user-attachments/assets/6b47d080-8488-49a6-b69f-b0e1cc2969de" />

---

## Bug Fix  
### DevBoard Task  
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2112

### Issue Summary  
Rename TDEI Job "Dataset BBox" to "Filter Dataset By BBox"

---

### Fix Implemented  
- Renamed the `dataset-bbox` option label from Dataset BBox to Filter Dataset By BBox in:  
  - Job Type dropdown (Create Job UI).
  - Job Type filter dropdown in the Jobs list UI.
  - Cells in the Jobs list where job type is displayed  
---

### Impacted Areas for Testing  
- Create New Job 
  - Open the Job Type dropdown -> verify Filter Dataset By BBox appears instead of Dataset BBox  

- Jobs List Page
  - For existing `dataset-bbox` jobs, confirm the job‑type column shows Filter Dataset By BBox

- Job Creation Payload
  - Submit a new `dataset-bbox` job -> verify the `job_type` value in the request remains `dataset-bbox` (only the UI label changed)  

---
 ### Screenshots :
 
 
<img width="1470" height="956" alt="Screenshot 2025-07-17 at 3 07 48 PM" src="https://github.com/user-attachments/assets/a38ce9d4-2e6e-408d-8f19-ff73a6e66eba" />
