### PR TITLE
fixed updating dataviewer badge on data set along with the project group level status

### DIFF
--- a/tdei-ui/src/routes/Datasets/DatasetRow.js
+++ b/tdei-ui/src/routes/Datasets/DatasetRow.js
@@ -127,7 +127,7 @@ const DatasetRow = ({ dataset, onAction, isReleasedList }) => {
                 >
                   {metadata.dataset_detail.name}{" "}
                 </span>
-                {data_viewer_allowed && (
+                {project_group.data_viewer_allowed && data_viewer_allowed && (
                   <Badge
                     bg="" // This disables the default bootstrap color
                     className="ms-2 d-inline-flex align-items-center"

--- a/tdei-ui/src/routes/Datasets/DatasetRow.js
+++ b/tdei-ui/src/routes/Datasets/DatasetRow.js
@@ -52,6 +52,7 @@ const DatasetRow = ({ dataset, onAction, isReleasedList }) => {
   const dataViewerProps = () => {
     const canPerformDataViewerAction =
       (isPoc || isOswGenerator) &&
+      project_group.data_viewer_allowed &&
       status === "Publish" &&
       project_group.tdei_project_group_id ===
         selectedProjectGroup.tdei_project_group_id &&


### PR DESCRIPTION
This pull request makes targeted improvements to the `DatasetRow` component in `tdei-ui/src/routes/Datasets/DatasetRow.js` to ensure that data viewer actions and badges are only available when both the project group and the dataset explicitly allow data viewer access. This enhances permission checks and UI accuracy.

**Permission and UI logic improvements:**

* Added a check for `project_group.data_viewer_allowed` to the conditions that determine if the data viewer action is available, ensuring that both user role and project group permissions are considered.
* Updated the rendering condition for the data viewer badge to require both `project_group.data_viewer_allowed` and `data_viewer_allowed` to be true, preventing the badge from displaying when either is not permitted.

https://github.com/user-attachments/assets/5caeccf8-a3b8-42d6-85b8-cefd079cfd7c

