### PR TITLE
Feature-task-2387-Onboarding flow changes

### DIFF
--- a/tdei-ui/src/components/RequireGuest/RequireGuest.js
+++ b/tdei-ui/src/components/RequireGuest/RequireGuest.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useAuth } from "../../hooks/useAuth";
+
+const RequireGuest = () => {
+  const { user } = useAuth();
+  const location = useLocation();
+
+  // If already logged in, don't allow guest pages
+  if (user) {
+    const to = (location.state && location.state.from && location.state.from.pathname) || "/";
+    return <Navigate to={to} replace />;
+  }
+  return <Outlet />;
+};
+
+export default RequireGuest;

--- a/tdei-ui/src/routes/Referral/InviteInstructions.js
+++ b/tdei-ui/src/routes/Referral/InviteInstructions.js
@@ -1,0 +1,171 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Button, Card, Container, Row, Col, Spinner } from "react-bootstrap";
+import ResponseToast from "../../components/ToastMessage/ResponseToast";
+import style from "./Referral.module.css";
+
+const isMobileLike = () => {
+    const ua = navigator.userAgent || "";
+    const isTouchMac = /Macintosh/i.test(ua) && navigator.maxTouchPoints > 1;
+    return /Android|iPhone|iPad|iPod|IEMobile|Opera Mini/i.test(ua) || isTouchMac;
+};
+
+function openDeepLink(url, onBlocked) {
+    const a = document.createElement("a");
+    a.href = url;
+    a.style.display = "none";
+    a.rel = "noopener";
+    document.body.appendChild(a);
+    a.click();
+
+    // try via iframe (works in some other browsers)
+    const iframe = document.createElement("iframe");
+    iframe.style.display = "none";
+    iframe.src = url;
+    document.body.appendChild(iframe);
+
+    // if the page is still visible after 1200ms, assume the app didn't open
+    const timer = setTimeout(() => {
+        const stillHere = !(document.hidden || document.webkitHidden);
+        if (stillHere) onBlocked?.();
+        cleanup();
+    }, 1200);
+
+    const cleanup = () => {
+        clearTimeout(timer);
+        try { iframe.remove(); } catch { }
+        try { a.remove(); } catch { }
+    };
+
+    // cleanup on blur/pagehide (user likely switched to app)
+    window.addEventListener("blur", cleanup, { once: true });
+    window.addEventListener("pagehide", cleanup, { once: true });
+}
+
+
+export default function InviteInstructions() {
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    // Fallback data saved by Register.js (sessionStorage.setItem('inviteRegPayload', ...))
+    const fallback = useMemo(() => {
+        try {
+            return JSON.parse(sessionStorage.getItem("inviteRegPayload") || "{}");
+        } catch {
+            return {};
+        }
+    }, []);
+
+    const state = (location && location.state) || {};
+    const instructionsUrl = state.instructions_url || fallback.instructions_url;
+    const oneTimeToken = state.oneTimeToken || fallback.oneTimeToken;
+    const email = state.email || fallback.email;
+
+    const [busy, setBusy] = useState(false);
+    const [toast, setToast] = useState({ show: false, msg: "", type: "success" });
+
+    useEffect(() => {
+        if (!instructionsUrl || !oneTimeToken) {
+            // Missing data -> go back to register
+            navigate("/register", { replace: true });
+        }
+    }, [instructionsUrl, oneTimeToken, navigate]);
+
+    const handleContinue = () => {
+        if (!oneTimeToken) return;
+
+        const env =
+            process.env.REACT_APP_DEEPLINK_ENV ||
+            process.env.REACT_APP_ENV ||
+            "dev";
+
+        const deepLink = `avivscr://?code=${encodeURIComponent(oneTimeToken)}&env=${encodeURIComponent(env)}`;
+
+        if (isMobileLike()) {
+            setBusy(true);
+            openDeepLink(deepLink, () => {
+                setToast({
+                    show: true,
+                    msg: "If the app didn’t open, install/open the app and try again.",
+                    type: "warning",
+                });
+                setBusy(false);
+            });
+            return;
+        }
+
+        // Desktop -> Workspaces FE
+        const workspacesUrl =
+            process.env.REACT_APP_TDEI_WORKSPACE_URL ||
+            `${window.location.origin}/workspaces`;
+        window.location.href = workspacesUrl;
+    };
+
+    return (
+        <div className={style.inviteContainer}>
+            <Container className="py-4">
+                <Row className="justify-content-center align-items-center">
+                    <Col lg={10} xl={9}>
+                        <Card>
+                            <Card.Header>
+                                <h5 className="mb-0">Complete Your Setup</h5>
+                            </Card.Header>
+                            <Card.Body>
+                                <p className="text-muted mb-3">
+                                    Please review the instructions below and then click <strong>Continue</strong>.
+                                </p>
+
+                                <div className="mb-3">
+                                    <small className="text-muted">Instructions URL</small>
+                                    <div className="text-break">{instructionsUrl}</div>
+                                </div>
+
+                                <div
+                                    style={{ border: "1px solid #e5e7eb", borderRadius: 8, overflow: "hidden" }}
+                                    className="mb-3"
+                                >
+                                    <iframe
+                                        src={instructionsUrl}
+                                        title="Instructions"
+                                        style={{ width: "100%", height: "50vh", border: 0 }}
+                                    />
+                                </div>
+
+                                <div className="d-flex gap-2">
+                                    <Button
+                                        className="tdei-primary-button"
+                                        onClick={handleContinue}
+                                        disabled={busy}
+                                    >
+                                        {busy ? (
+                                            <>
+                                                <Spinner size="sm" animation="border" className="me-2" />
+                                                Processing…
+                                            </>
+                                        ) : (
+                                            "Continue"
+                                        )}
+                                    </Button>
+                                    <Button
+                                        variant="outline-secondary"
+                                        className="tdei-secondary-button"
+                                        onClick={() => window.open(instructionsUrl, "_blank")}
+                                    >
+                                        Open in New Tab
+                                    </Button>
+                                </div>
+                            </Card.Body>
+                        </Card>
+                    </Col>
+                </Row>
+
+                <ResponseToast
+                    showtoast={toast.show}
+                    handleClose={() => setToast({ ...toast, show: false })}
+                    message={toast.msg}
+                    type={toast.type}
+                />
+            </Container>
+        </div>
+    );
+}

--- a/tdei-ui/src/routes/Referral/InviteInstructions.js
+++ b/tdei-ui/src/routes/Referral/InviteInstructions.js
@@ -16,7 +16,7 @@ function openDeepLink(url, onBlocked) {
     document.body.appendChild(a);
     a.click();
 
-    // try via iframe (works in some other browsers)
+    // try via iframe
     const iframe = document.createElement("iframe");
     iframe.style.display = "none";
     iframe.src = url;
@@ -44,6 +44,8 @@ function openDeepLink(url, onBlocked) {
 export default function InviteInstructions() {
     const location = useLocation();
     const navigate = useNavigate();
+    const env = (process.env.REACT_APP_ENV || "dev").trim();
+    
 
     // Fallback data saved by Register.js (sessionStorage.setItem('inviteRegPayload', ...))
     const fallback = useMemo(() => {
@@ -73,36 +75,7 @@ export default function InviteInstructions() {
     const isMobileUA = () =>
         /Android|iPhone|iPad|iPod|IEMobile|Opera Mini/i.test(navigator.userAgent || "");
 
-    // const handleContinue = () => {
-    //     if (!oneTimeToken) return;
-
-    //     const env =
-    //         process.env.REACT_APP_DEEPLINK_ENV ||
-    //         process.env.REACT_APP_ENV ||
-    //         "dev";
-
-    //     const deepLink = `avivscr://?code=${encodeURIComponent(oneTimeToken)}&env=${encodeURIComponent(env)}`;
-
-    //     if (isMobileLike()) {
-    //         setBusy(true);
-    //         openDeepLink(deepLink, {
-    //             onOpened: () => { clearInvite(); /* app opened */ },
-    //             onBlocked: () => {
-    //                 setBusy(false);
-    //                 // Keep inviteRegPayload for retry
-    //                 setToast({ show: true, type: "warning", msg: "If the app didn’t open, open it manually and try again." });
-    //             }
-    //         });
-    //         return;
-    //     }
-    //     clearInvite();
-    //     // Desktop -> Workspaces FE
-    //     const workspacesUrl =
-    //         process.env.REACT_APP_TDEI_WORKSPACE_URL ||
-    //         `${window.location.origin}/workspaces`;
-    //     window.location.href = workspacesUrl;
-    // };
-
+    // Continue button handler: call refresh-token API, handle deep link (mobile) or redirect (desktop)
     const handleContinue = async () => {
         if (!oneTimeToken) return;
         setBusy(true);
@@ -124,8 +97,10 @@ export default function InviteInstructions() {
             sessionStorage.removeItem("inviteRegPayload");
 
             if (isMobileUA()) {
-                // mobile deep link with *refresh* token
-                window.location.href = `avivscr://?code=${encodeURIComponent(refresh)}`;
+                // mobile deep link with refresh token
+                const deeplink =
+                    `avivscr://?code=${encodeURIComponent(refresh)}&env=${encodeURIComponent(env)}`;
+                window.location.href = deeplink;
             } else {
                 // desktop redirect to Workspaces FE
                 const workspacesUrl =

--- a/tdei-ui/src/routes/Referral/Referral.js
+++ b/tdei-ui/src/routes/Referral/Referral.js
@@ -17,18 +17,21 @@ import useGetProjectGroupById from "../../hooks/projectGroup/useGetProjectGroupB
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 
 
-const mapApiToUi = (item) => ({
-  id: item.id,
-  name: item.name,
-  type: item.type === 1 ? "campaign" : "invite",
-  shortCode: item.code,
-  instructionsUrl: item.instructions_url || "",
-  validFrom: item.valid_from || null,
-  validTo: item.valid_to || null,
-  createdAt: item.created_at || null,
-  isActive: Boolean(item.is_active),
-  shareLink: `${process.env.REACT_APP_JOIN_BASE_URL || "https://app.example.com"}/join/${item.code}`,
-});
+const mapApiToUi = (item) => {
+  const base = (process.env.REACT_APP_PORTAL_URL || "https://portal-dev.tdei.us").replace(/\/+$/, "");
+  return {
+    id: item.id,
+    name: item.name,
+    type: item.type === 1 ? "campaign" : "invite",
+    shortCode: item.code,
+    instructionsUrl: item.instructions_url || "",
+    validFrom: item.valid_from || null,
+    validTo: item.valid_to || null,
+    createdAt: item.created_at || null,
+    isActive: Boolean(item.is_active),
+    shareLink: `${base}/register?code=${encodeURIComponent(item.code)}`,
+  };
+};
 
 const typeOptions = [
   { value: "", label: "All" },

--- a/tdei-ui/src/routes/Referral/Referral.module.css
+++ b/tdei-ui/src/routes/Referral/Referral.module.css
@@ -932,3 +932,9 @@
   border-color: var(--primary-color) !important;
   box-shadow: none !important;
 }
+.inviteContainer {
+  background-image: url(./../../../public/assets/img/bg_login.png);
+  background-repeat: no-repeat;
+  background-size: cover;
+  min-height: calc(100vh - 60px);
+}

--- a/tdei-ui/src/routes/Register/Register.js
+++ b/tdei-ui/src/routes/Register/Register.js
@@ -89,13 +89,16 @@ const Register = () => {
       const res = await axios.post(`${process.env.REACT_APP_URL}/register`, payload);
       const data = res?.data?.data;
 
+      const instructionsUrl = data?.instructionsUrl || data?.instructions_url || "";
+      const oneTimeToken    = data?.token || "";
+
       setToastMessage("Registration successful!");
       setToastType("success");
       setShowToast(true);
       setLoading(false);
 
       // Branch based on presence of instructions_url
-      if (data?.instructions_url && data?.token) {
+    if (instructionsUrl || oneTimeToken) {
         // persist in sessionStorage as a fallback in case user refreshes page
         sessionStorage.setItem(
           "inviteRegPayload",
@@ -309,6 +312,26 @@ const Register = () => {
                       >
                         {loading ? "Creating Account..." : "Create Account"}
                       </Button>
+                      {inviteCode && (
+                        <div className={style.inviteNote} role="note" aria-live="polite">
+                          <svg
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                            className={style.inviteIcon}
+                          >
+                            <path
+                              d="M12 2a10 10 0 1 0 .001 20.001A10 10 0 0 0 12 2zm0 14.25a.75.75 0 1 1 0 1.5h-1.5a.75.75 0 1 1 0-1.5H12zm0-9a1.25 1.25 0 1 1 0 2.5A1.25 1.25 0 0 1 12 7.25zm0 3a.75.75 0 0 1 .75.75v3.5a.75.75 0 1 1-1.5 0V11a.75.75 0 0 1 .75-.75z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                          <span className={style.inviteText}>
+                            Registering with referral code
+                          </span>
+                          <code className={style.inviteCode}>{inviteCode}</code>
+                        </div>
+                      )}
                       <div className="mt-5">
                         Already have an account?{" "}
                         <Link className="tdei-primary-link" to={"/login"}>

--- a/tdei-ui/src/routes/Register/style.module.css
+++ b/tdei-ui/src/routes/Register/style.module.css
@@ -2,22 +2,68 @@
   max-width: 450px;
   margin-top: 50px;
 }
+
 .registerContainer {
   background-image: url(./../../../public/assets/img/bg_login.png);
   background-repeat: no-repeat;
   background-size: cover;
   min-height: calc(100vh - 60px);
 }
+
 .loginLogo {
   width: 100px;
   margin: 25px 0px;
 }
+
 @media only screen and (max-width: 600px) {
   .registerCard {
     margin-top: 0px;
     max-width: 100%;
+
     :global .card {
-        border: none;
+      border: none;
     }
+  }
+}
+
+.inviteNote {
+  margin-top: 12px;
+  padding: 10px 12px;
+  background: var(--purple-background-light);
+  border: 1px solid var(--primary-color);
+  border-radius: 10px;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: var(--primary-color);
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.inviteIcon {
+  flex: 0 0 auto;
+  opacity: 0.85;
+  margin-top: 2px;
+}
+
+.inviteText {
+  white-space: normal;
+}
+
+.inviteCode {
+  flex: 1 1 100%;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background: #ffffff;
+  color: var(--primary-color);
+  border: 1px dashed var(--primary-color);
+  padding: 2px 8px;
+  border-radius: 6px;
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+
+@media (min-width: 480px) {
+  .inviteCode {
+    flex: 0 0 auto;
   }
 }

--- a/tdei-ui/src/routes/index.js
+++ b/tdei-ui/src/routes/index.js
@@ -27,6 +27,8 @@ import Feedback from "./Feedback";
 import Reports from "./Reports/Reports";
 import Referral from "./Referral/Referral";
 import CreateUpdateReferralCode from "./Referral/CreateUpdateReferralCode";
+import RequireGuest from "../components/RequireGuest/RequireGuest";
+import InviteInstructions from "./Referral/InviteInstructions";
 
 const Router = () => {
   const { user } = useAuth();
@@ -34,11 +36,14 @@ const Router = () => {
   return (
     <Routes>
       <>
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/register" element={<Register />} />
-        <Route path="/ForgotPassword" element={<ForgotPassword />} />
-        <Route path="/passwordReset" element={<PasswordResetConfirm />} />
-        <Route path="/emailVerify" element={<EmailVerification />} />
+        <Route element={<RequireGuest />}>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<Register />} />
+          <Route path="/ForgotPassword" element={<ForgotPassword />} />
+          <Route path="/passwordReset" element={<PasswordResetConfirm />} />
+          <Route path="/emailVerify" element={<EmailVerification />} />
+          <Route path="/invite-instructions" element={<InviteInstructions />} />
+        </Route>
         <Route element={<RequireAuth />}>
           <Route path="/" element={<Root />}>
             <Route path="/" element={<Dashboard />} />


### PR DESCRIPTION
## DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/2387

### Changes Introduced

* Register: Added referral params to `?code=…`; include `code` in payload.
* Post-register:

  * If `instructionsUrl` OR `token` -> go to /invite-instructions.
  * Else -> /emailVerify (normal flow).
* Invite Instructions:

  * Show iframe only if `instructionsUrl` exists.
  * Continue -> `POST /refresh-token`, save tokens.
  * Mobile: open `avivscr://?code=<refresh_token>&env=<env>`. Desktop: redirect to Workspaces FE.
  * Clear `inviteRegPayload` on success.
* Auth/Routing: add /invite-instructions to anonymous allowlist; keep re-login modal behavior.
* Share link: `<PORTAL_BASE>/register?code={shortCode}`.

### Impacted Areas for Testing

* Referral Param Handling
    * Hitting /register?refferal_code=NHPY or /register?referral_code=NHPY redirects to /register?code=NHPY.
    * The code is included in the register payload when submitting.
* Register Response Branching
    * instructionsUrl + token → navigates to InviteInstructions, iframe renders URL, Continue works.
    * token only (no instructionsUrl) → navigates to InviteInstructions without iframe, Continue still works.
    * Neither present → goes to /emailVerify (still guest-accessible).
* Refresh-Token Exchange
    * POST /refresh-token is sent with empty body and header refresh_token: <oneTimeToken>.
    * Response access_token/refresh_token saved to localStorage.
* Deep Link / Redirect
    * Mobile: Continue opens avivscr://?code=<refresh_token>&env=<env>.
    * Desktop: Continue redirects to REACT_APP_WORKSPACES_URL (fallback /workspaces).
* Auth Guard / UX
    * Visiting /invite-instructions without an access token does not show the toast.
    * Real expiry on protected route shows toast and redirects appropriately.
    * Re-login modal still functions as before.
* UI Note
    * Referral note appears only when inviteCode exists
* Share Link
    * Generated share links display as <portal>/register?code={shortCode} and open the register page with the code pre-filled.

### Screenshots
<img width="1463" height="877" alt="Screenshot 2025-10-06 at 5 05 18 PM" src="https://github.com/user-attachments/assets/f9ef8d33-6cf8-4311-9730-633593d21b4d" />
<img width="1470" height="879" alt="Screenshot 2025-10-06 at 5 18 24 PM" src="https://github.com/user-attachments/assets/3789799e-c1e2-459b-89f4-c8024901794e" />
<img width="1465" height="873" alt="Screenshot 2025-10-06 at 5 35 26 PM" src="https://github.com/user-attachments/assets/760034d1-b972-44b3-9c35-b13a2d1fd936" />
<img width="1470" height="875" alt="Screenshot 2025-10-06 at 11 09 42 AM" src="https://github.com/user-attachments/assets/77ce8599-48f6-4d88-a56d-b136fc6d5122" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2025-10-06 at 20 24 28" src="https://github.com/user-attachments/assets/8c4f94e7-f1d3-49f2-8eb8-a86283f00ca6" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2025-10-06 at 20 25 24" src="https://github.com/user-attachments/assets/6b59f2cf-7096-4b99-a9ee-b01c2b2a50a8" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2025-10-06 at 20 25 29" src="https://github.com/user-attachments/assets/54c0cb6c-e9e8-4e33-a297-7b3f2d6d3eec" />


