### PR TITLE
Hide share-dataset flow with feature flag in prod

### DIFF
--- a/tdei-ui/src/components/AuthProvider/AuthProvider.js
+++ b/tdei-ui/src/components/AuthProvider/AuthProvider.js
@@ -8,7 +8,7 @@ import ResponseToast from "../ToastMessage/ResponseToast";
 import { clear } from "../../store";
 import { useDispatch } from "react-redux";
 import { useQueryClient } from "react-query";
-import { isShareDatasetRoute } from "../../utils";
+import { isShareDatasetRoute, SHOW_SHARE_DATASET_FLOW } from "../../utils";
 
 const AuthProvider = ({ children }) => {
   const navigate = useNavigate();
@@ -37,9 +37,9 @@ const AuthProvider = ({ children }) => {
 
     return anonymousPaths.has(normalizedPath)
       || normalizedPath.startsWith("/app-link/")
-      || normalizedPath.startsWith("/login/share-dataset/")
-      || normalizedPath.startsWith("/register/share-dataset/")
-      || isShareDatasetRoute(normalizedPath);
+      || (SHOW_SHARE_DATASET_FLOW && normalizedPath.startsWith("/login/share-dataset/"))
+      || (SHOW_SHARE_DATASET_FLOW && normalizedPath.startsWith("/register/share-dataset/"))
+      || (SHOW_SHARE_DATASET_FLOW && isShareDatasetRoute(normalizedPath));
   }, []);
 
   const decodeToken = (accessToken) => {

--- a/tdei-ui/src/components/RequireAuth/RequireAuth.js
+++ b/tdei-ui/src/components/RequireAuth/RequireAuth.js
@@ -2,13 +2,13 @@ import React from "react";
 import { matchPath, Navigate, Outlet } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
 import { useLocation } from "react-router-dom";
-import { buildShareDatasetAuthPath, isShareDatasetRoute } from "../../utils";
+import { buildShareDatasetAuthPath, isShareDatasetRoute, SHOW_SHARE_DATASET_FLOW } from "../../utils";
 
 function RequireAuth() {
   const { user } = useAuth();
   const location = useLocation();
   if (!user) {
-    if (isShareDatasetRoute(location.pathname)) {
+    if (SHOW_SHARE_DATASET_FLOW && isShareDatasetRoute(location.pathname)) {
       const shareMatch = matchPath(
         "/share-dataset/:data_type/:tdei_dataset_id",
         location.pathname

--- a/tdei-ui/src/components/RequireGuest/RequireGuest.js
+++ b/tdei-ui/src/components/RequireGuest/RequireGuest.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { matchPath, Navigate, Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
-import { buildShareDatasetPath } from "../../utils";
+import { buildShareDatasetPath, SHOW_SHARE_DATASET_FLOW } from "../../utils";
 
 const RequireGuest = () => {
   const { user } = useAuth();
@@ -9,26 +9,28 @@ const RequireGuest = () => {
 
   // If already logged in, don't allow guest pages
   if (user) {
-    const loginShareMatch = matchPath(
-      "/login/share-dataset/:data_type/:tdei_dataset_id",
-      location.pathname
-    );
-    const registerShareMatch = matchPath(
-      "/register/share-dataset/:data_type/:tdei_dataset_id",
-      location.pathname
-    );
-    const shareMatch = loginShareMatch || registerShareMatch;
-
-    if (shareMatch?.params?.data_type && shareMatch?.params?.tdei_dataset_id) {
-      return (
-        <Navigate
-          to={buildShareDatasetPath(
-            shareMatch.params.data_type,
-            shareMatch.params.tdei_dataset_id
-          )}
-          replace
-        />
+    if (SHOW_SHARE_DATASET_FLOW) {
+      const loginShareMatch = matchPath(
+        "/login/share-dataset/:data_type/:tdei_dataset_id",
+        location.pathname
       );
+      const registerShareMatch = matchPath(
+        "/register/share-dataset/:data_type/:tdei_dataset_id",
+        location.pathname
+      );
+      const shareMatch = loginShareMatch || registerShareMatch;
+
+      if (shareMatch?.params?.data_type && shareMatch?.params?.tdei_dataset_id) {
+        return (
+          <Navigate
+            to={buildShareDatasetPath(
+              shareMatch.params.data_type,
+              shareMatch.params.tdei_dataset_id
+            )}
+            replace
+          />
+        );
+      }
     }
 
     const to = (location.state && location.state.from) || "/";

--- a/tdei-ui/src/routes/Datasets/DatasetsActions.js
+++ b/tdei-ui/src/routes/Datasets/DatasetsActions.js
@@ -19,6 +19,7 @@ import useIsMember from "../../hooks/roles/useIsMember";
 import { useAuth } from "../../hooks/useAuth";
 import useIsDataTypeGenerator from "../../hooks/useIsDataTypeGenerator";
 import { useMediaQuery } from 'react-responsive';
+import { SHOW_SHARE_DATASET_FLOW } from "../../utils";
 
 const DatasetsActions = ({
   status,
@@ -107,7 +108,7 @@ const DatasetsActions = ({
       icon: downloadDatasetImg,
       condition: true,
     },
-    (isReleasedDataset || status === "Publish") && {
+    SHOW_SHARE_DATASET_FLOW && (isReleasedDataset || status === "Publish") && {
       key: "shareDataset",
       label: "Share Link",
       icon: copyIcon,

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -25,7 +25,7 @@ import ProjectAutocomplete from "../../components/ProjectAutocomplete/ProjectAut
 import ServiceAutocomplete from "../../components/ServiceAutocomplete/ServiceAutocomplete";
 import DownloadModal from "../../components/DownloadModal/DownloadModal";
 import useCreateQualityReportJob from "../../hooks/jobs/useCreateQualityReportJob";
-import { buildShareDatasetPath } from "../../utils";
+import { buildShareDatasetPath, SHOW_SHARE_DATASET_FLOW } from "../../utils";
 
 const MyDatasets = () => {
   const queryClient = useQueryClient();
@@ -260,6 +260,14 @@ const MyDatasets = () => {
   };
 
   const copyShareLink = async (dataset) => {
+    if (!SHOW_SHARE_DATASET_FLOW) {
+      setEventKey("shareDataset");
+      setOperationResult("error");
+      setCustomErrorMessage("Share links are disabled in this branch.");
+      handleToast();
+      return;
+    }
+
     const sharePath = buildShareDatasetPath(
       dataset?.data_type,
       dataset?.tdei_dataset_id

--- a/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
+++ b/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
@@ -8,7 +8,7 @@ import { Button, Form, Spinner, Col, Row } from "react-bootstrap";
 import style from "./Datasets.module.css";
 import Select from 'react-select';
 import iconNoData from "./../../assets/img/icon-noData.svg";
-import { buildShareDatasetPath, toPascalCase, formatDate } from '../../utils';
+import { buildShareDatasetPath, SHOW_SHARE_DATASET_FLOW, toPascalCase, formatDate } from '../../utils';
 import SortRefreshComponent from './SortRefreshComponent';
 import useGetReleasedDatasets from '../../hooks/service/useGetReleaseDatasets';
 import useDownloadDataset from '../../hooks/datasets/useDownloadDataset';
@@ -159,6 +159,14 @@ const ReleasedDatasets = () => {
   const handleRefresh = () => refreshData();
 
   const copyShareLink = async (dataset) => {
+    if (!SHOW_SHARE_DATASET_FLOW) {
+      setEventKey("shareDataset");
+      setOperationResult("error");
+      setCustomErrorMessage("Share links are disabled in this branch.");
+      handleToast();
+      return;
+    }
+
     const sharePath = buildShareDatasetPath(dataset?.data_type, dataset?.tdei_dataset_id);
     const shareUrl = `${window.location.origin}${sharePath}`;
 

--- a/tdei-ui/src/routes/Root/Root.js
+++ b/tdei-ui/src/routes/Root/Root.js
@@ -8,6 +8,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { set } from "../../store";
 import { Outlet } from "react-router-dom";
 import ShareDatasetModalHost from "../../components/ShareDataset/ShareDatasetModalHost";
+import { SHOW_SHARE_DATASET_FLOW } from "../../utils";
 
 const Root = () => {
   const { data: projectGroupData, isLoading: isProjectGroupLoading, isError } = useGetProjectGroupRoles();
@@ -65,7 +66,7 @@ const Root = () => {
           <Navigation />
           <main className={style.contentBlock} id="main-content" tabIndex={-1}>
             <Outlet roles={roles} />
-            <ShareDatasetModalHost />
+            {SHOW_SHARE_DATASET_FLOW && <ShareDatasetModalHost />}
           </main>
         </div>
       )}

--- a/tdei-ui/src/routes/index.js
+++ b/tdei-ui/src/routes/index.js
@@ -30,7 +30,7 @@ import CreateUpdateReferralCode from "./Referral/CreateUpdateReferralCode";
 import RequireGuest from "../components/RequireGuest/RequireGuest";
 import InviteInstructions from "./Referral/InviteInstructions";
 import AppLinkFallback from "../AppLinkFallback";
-import { SHOW_REFERRALS } from "../utils/helper";
+import { SHOW_REFERRALS, SHOW_SHARE_DATASET_FLOW } from "../utils";
 
 const Router = () => {
   const { user } = useAuth();
@@ -40,9 +40,13 @@ const Router = () => {
       <>
         <Route element={<RequireGuest />}>
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/login/share-dataset/:data_type/:tdei_dataset_id" element={<LoginPage />} />
+          {SHOW_SHARE_DATASET_FLOW && (
+            <Route path="/login/share-dataset/:data_type/:tdei_dataset_id" element={<LoginPage />} />
+          )}
           <Route path="/register" element={<Register />} />
-          <Route path="/register/share-dataset/:data_type/:tdei_dataset_id" element={<Register />} />
+          {SHOW_SHARE_DATASET_FLOW && (
+            <Route path="/register/share-dataset/:data_type/:tdei_dataset_id" element={<Register />} />
+          )}
           <Route path="/ForgotPassword" element={<ForgotPassword />} />
           <Route path="/passwordReset" element={<PasswordResetConfirm />} />
           <Route path="/emailVerify" element={<EmailVerification />} />
@@ -56,7 +60,9 @@ const Router = () => {
         <Route element={<RequireAuth />}>
           <Route path="/" element={<Root />}>
             <Route path="/" element={<Dashboard />} />
-            <Route path="/share-dataset/:data_type/:tdei_dataset_id" element={<Dashboard />} />
+            {SHOW_SHARE_DATASET_FLOW && (
+              <Route path="/share-dataset/:data_type/:tdei_dataset_id" element={<Dashboard />} />
+            )}
             {user?.isAdmin && (
               <Route path="/projectGroup" element={<ProjectGroup />} />
             )}

--- a/tdei-ui/src/utils/shareDataset.js
+++ b/tdei-ui/src/utils/shareDataset.js
@@ -1,5 +1,7 @@
 const SHARE_DATASET_ROUTE_PREFIX = "/share-dataset";
 
+export const SHOW_SHARE_DATASET_FLOW = false;
+
 export const DEFAULT_SHARE_REFERRAL_CODE =
   process.env.REACT_APP_DEFAULT_SHARE_REFERRAL_CODE || "";
 


### PR DESCRIPTION
This pull request introduces a new feature flag, `SHOW_SHARE_DATASET_FLOW`, to control the availability of the share dataset flow throughout the application. This allows the share dataset functionality to be easily enabled or disabled from a single place, improving maintainability and flexibility for different deployment environments. The flag is checked in routing, UI rendering, and action logic to ensure consistent behavior when the feature is toggled.

Feature flag integration for share dataset flow:

* Added `SHOW_SHARE_DATASET_FLOW` constant (default `false`) to `shareDataset.js` and imported it throughout the codebase to control whether share dataset routes and UI are available. [[1]](diffhunk://#diff-4a49db546afc5a043ba4e03222d692196b529ba225abf036be5802d1240cfaaeR3-R4) [[2]](diffhunk://#diff-d8091a88c62b64b5e57e36031b927042b36943ecceeea45a9eceda05fca416afL11-R11) [[3]](diffhunk://#diff-2541f0126e5f02438940b2bb4b8173e3658945b040487151ba94eb94721f8e1eL5-R11) [[4]](diffhunk://#diff-aec8e894a20b966bd30668dba650035a20148fb74c0c7c4efb258b66283225e0L4-R12) [[5]](diffhunk://#diff-bb6cd38fe2f114490828c24593bbde9dec4bf048a7724be11271679e911b4ca9R22) [[6]](diffhunk://#diff-70e6d08b2ca571680db14cc503d7dde4bbab8dd4752d20f6b46214155386d8f9L28-R28) [[7]](diffhunk://#diff-ee3876460ed7cae7da1afa856ec86a26ea75a72ce4a7a31a4cb3431ed442f579L11-R11) [[8]](diffhunk://#diff-403d86b10e2c4e2dd4729932736d06c543ded7a78150cc9f9251c02526d741acR11) [[9]](diffhunk://#diff-d4f26131d145b496cdd40ca684020a0d0fc2a7cdef7375c9e6d7ca7fd4b4181dL33-R33)

Routing and access control updates:

* Updated route definitions in `index.js` to conditionally include share dataset login, register, and dashboard routes only when `SHOW_SHARE_DATASET_FLOW` is true. [[1]](diffhunk://#diff-d4f26131d145b496cdd40ca684020a0d0fc2a7cdef7375c9e6d7ca7fd4b4181dR43-R49) [[2]](diffhunk://#diff-d4f26131d145b496cdd40ca684020a0d0fc2a7cdef7375c9e6d7ca7fd4b4181dR63-R65)
* Modified `RequireAuth` and `RequireGuest` components to check `SHOW_SHARE_DATASET_FLOW` before allowing access to share dataset routes. [[1]](diffhunk://#diff-2541f0126e5f02438940b2bb4b8173e3658945b040487151ba94eb94721f8e1eL5-R11) [[2]](diffhunk://#diff-aec8e894a20b966bd30668dba650035a20148fb74c0c7c4efb258b66283225e0L4-R12) [[3]](diffhunk://#diff-aec8e894a20b966bd30668dba650035a20148fb74c0c7c4efb258b66283225e0R34) [[4]](diffhunk://#diff-d8091a88c62b64b5e57e36031b927042b36943ecceeea45a9eceda05fca416afL40-R42)

UI and action logic adjustments:

* Updated dataset-related components (`DatasetsActions.js`, `MyDatasets.js`, `ReleasedDatasets.js`) to show or execute share link actions only if `SHOW_SHARE_DATASET_FLOW` is enabled, including user feedback when disabled. [[1]](diffhunk://#diff-bb6cd38fe2f114490828c24593bbde9dec4bf048a7724be11271679e911b4ca9L110-R111) [[2]](diffhunk://#diff-70e6d08b2ca571680db14cc503d7dde4bbab8dd4752d20f6b46214155386d8f9R263-R270) [[3]](diffhunk://#diff-ee3876460ed7cae7da1afa856ec86a26ea75a72ce4a7a31a4cb3431ed442f579R162-R169)
* Conditionally rendered `ShareDatasetModalHost` in the main layout based on the feature flag.