### PR TITLE
Dev To Stage

### DIFF
--- a/tdei-ui/src/components/DatasetAutocomplete/DatasetAutocomplete.js
+++ b/tdei-ui/src/components/DatasetAutocomplete/DatasetAutocomplete.js
@@ -20,9 +20,12 @@ const DatasetAutocomplete = ({
   const [pageNo, setPageNo] = useState(1);
   const [selectedDataset, setSelectedDataset] = useState(null);
   const [showDropdown, setShowDropdown] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [announcement, setAnnouncement] = useState("");
 
   const observer = useRef();
   const autocompleteRef = useRef();
+  const listRef = useRef();
 
   // Debounce user input
   const debouncedSearch = useMemo(
@@ -53,7 +56,38 @@ const DatasetAutocomplete = ({
 
     debouncedSearch(value);
     setShowDropdown(true);
+    setHighlightedIndex(-1);
   };
+
+  const handleKeyDown = (e) => {
+    if (!showDropdown || deduplicatedDatasets.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        prev < deduplicatedDatasets.length - 1 ? prev + 1 : prev
+      );
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (highlightedIndex >= 0 && highlightedIndex < deduplicatedDatasets.length) {
+        handleSelect(deduplicatedDatasets[highlightedIndex]);
+      }
+    } else if (e.key === "Escape" || e.key === "Tab") {
+      if (e.key === "Tab") e.preventDefault();
+      setShowDropdown(false);
+      setHighlightedIndex(-1);
+    }
+  };
+
+  // Scroll highlighted item into view AFTER render
+  useEffect(() => {
+    if (highlightedIndex >= 0 && listRef.current) {
+      const item = listRef.current.children[highlightedIndex];
+      if (item) item.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlightedIndex]);
 
 
   const { loading, datasetList, hasMore } = useGetDatasetsAutocomplete(debouncedValue, pageNo);
@@ -67,6 +101,21 @@ const DatasetAutocomplete = ({
       return true;
     });
   }, [datasetList]);
+
+  // Announce result count to screen readers when dropdown opens
+  useEffect(() => {
+    if (showDropdown && !loading && deduplicatedDatasets.length > 0) {
+      setAnnouncement(
+        `${deduplicatedDatasets.length} result${
+          deduplicatedDatasets.length === 1 ? "" : "s"
+        } available. Use arrow keys to navigate.`
+      );
+    } else if (showDropdown && !loading && deduplicatedDatasets.length === 0) {
+      setAnnouncement("No datasets found.");
+    } else {
+      setAnnouncement("");
+    }
+  }, [showDropdown, loading, deduplicatedDatasets.length]);
 
   const lastDataset = useCallback(
     (node) => {
@@ -91,6 +140,7 @@ const DatasetAutocomplete = ({
     setSelectedDataset(ds);
     setDatasetSearchText(labelFor(ds));
     setShowDropdown(false);
+    setHighlightedIndex(-1);
     onSelectDataset(ds.tdei_dataset_id || null);
   };
 
@@ -122,9 +172,25 @@ const DatasetAutocomplete = ({
   }, [handleClickOutside, debouncedSearch]);
 
   const inputValue = datasetSearchText;
+  const listboxId = id ? `${id}-listbox` : "dataset-listbox";
+  const activeDescendant =
+    highlightedIndex >= 0 && deduplicatedDatasets[highlightedIndex]
+      ? `${listboxId}-option-${deduplicatedDatasets[highlightedIndex].tdei_dataset_id}`
+      : undefined;
+  const isExpanded = showDropdown && deduplicatedDatasets.length > 0;
 
   return (
     <div className={styles.autocompleteContainer} ref={autocompleteRef}>
+      {/* Live region — screen readers announce results count */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{ position: "absolute", width: "1px", height: "1px", overflow: "hidden", clip: "rect(0,0,0,0)", whiteSpace: "nowrap" }}
+      >
+        {announcement}
+      </div>
+
       <InputGroup>
         <Form.Control
           id={id}
@@ -133,55 +199,57 @@ const DatasetAutocomplete = ({
           onChange={handleInputChange}
           value={inputValue}
           onFocus={() => setShowDropdown(true)}
+          onKeyDown={handleKeyDown}
           autoComplete="off"
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded={isExpanded}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={activeDescendant}
+          aria-label={placeholder}
         />
         {inputValue && (
           <InputGroup.Text>
-            <IconButton size="small" onClick={clearAll}>
+            <IconButton size="small" onClick={clearAll} aria-label="Clear selection">
               <ClearIcon fontSize="small" />
             </IconButton>
           </InputGroup.Text>
         )}
         {loading && (
           <InputGroup.Text>
-            <Spinner animation="border" size="sm" />
+            <Spinner animation="border" size="sm" aria-label="Loading results" />
           </InputGroup.Text>
         )}
       </InputGroup>
 
       {showDropdown && deduplicatedDatasets.length > 0 && (
-        <div className={styles.dropdownList}>
+        <div
+          role="listbox"
+          id={listboxId}
+          aria-label="Datasets"
+          className={styles.dropdownList}
+          ref={listRef}
+          tabIndex="-1"
+        >
           {deduplicatedDatasets.map((ds, idx) => {
-            const content = (
-              <>
-                <div className={styles.primaryText}>{labelFor(ds)}</div>
-              </>
-            );
-
+            const optionId = `${listboxId}-option-${ds.tdei_dataset_id}`;
+            const isHighlighted = highlightedIndex === idx;
             const isActive = selectedDataset?.tdei_dataset_id === ds.tdei_dataset_id;
-
-            if (deduplicatedDatasets.length === idx + 1) {
-              return (
-                <div
-                  key={ds.tdei_dataset_id}
-                  id={ds.tdei_dataset_id}
-                  className={`${styles.dropdownItem} ${isActive ? styles.active : ""}`}
-                  onClick={() => handleSelect(ds)}
-                  ref={lastDataset}
-                >
-                  {content}
-                </div>
-              );
-            }
 
             return (
               <div
                 key={ds.tdei_dataset_id}
-                id={ds.tdei_dataset_id}
-                className={`${styles.dropdownItem} ${isActive ? styles.active : ""}`}
+                id={optionId}
+                role="option"
+                aria-selected={isActive}
+                className={`${styles.dropdownItem} ${
+                  isHighlighted ? styles.highlighted : isActive ? styles.active : ""
+                }`}
                 onClick={() => handleSelect(ds)}
+                ref={deduplicatedDatasets.length === idx + 1 ? lastDataset : null}
               >
-                {content}
+                <div className={styles.primaryText}>{labelFor(ds)}</div>
               </div>
             );
           })}

--- a/tdei-ui/src/components/JobListItem/JobListItem.js
+++ b/tdei-ui/src/components/JobListItem/JobListItem.js
@@ -170,11 +170,12 @@ const JobListItem = ({ jobItem }) => {
   return (
     <div className={style.gridContainer} key={jobItem.tdei_project_group_id}>
       <div className={style.content}>
-        <div className={style.mobileOnly}>Job Type</div>
+        <div className={style.mobileOnly} aria-hidden="true">Job Type</div>
+        <span className="visually-hidden">Job Type: </span>
         {displayJobType}
       </div>
       <div className={style.content}>
-        <div className={style.mobileOnly}>Job Id</div>
+        <div className={style.mobileOnly} aria-hidden="true">Job Id</div>
         Job Id:
         <button
           type="button"
@@ -186,7 +187,7 @@ const JobListItem = ({ jobItem }) => {
         </button>
       </div>
       <div className={style.content}>
-        <div className={style.mobileOnly}>Submitted By</div>
+        <div className={style.mobileOnly} aria-hidden="true">Submitted By</div>
         <div className={style.submittedByBlock}>
           <img src={UserIcon} alt="" className={style.userIcon} />
           <span
@@ -196,15 +197,17 @@ const JobListItem = ({ jobItem }) => {
                 : style.emailContentNoWrap
             }
           >
+            <span className="visually-hidden">Submitted By: </span>
             {jobItem.requested_by}
           </span>
         </div>
       </div>
       <div className={style.content}>
-        <div className={style.mobileOnly}>Message</div>
+        <div className={style.mobileOnly} aria-hidden="true">Message</div>
         {jobItem.message && (
           <>
             <div className={style.errorMessageContent}>
+              <span className="visually-hidden">Message: </span>
               {jobItem.message.length > 70
                 ? `${jobItem.message.slice(0, 70)}...`
                 : `${jobItem.message}`}
@@ -278,13 +281,15 @@ const JobListItem = ({ jobItem }) => {
         }
       </div>
       <div className={style.content}>
-        <div className={style.mobileOnly}>Created On</div>
+        <div className={style.mobileOnly} aria-hidden="true">Created On</div>
+        <span className="visually-hidden">Created On: </span>
         {updatedTime(jobItem.created_at)}
       </div>
       <div className={style.statusFlexBox}>
-        <div className={style.mobileOnly}>Status</div>
+        <div className={style.mobileOnly} aria-hidden="true">Status</div>
         <div className="">
           <div className={style.statusContainer} style={{ "--background-color": getBackgroundColor(jobItem.status.toLowerCase()), "--border-color": getBorderColor(jobItem.status.toLowerCase()) }}>
+            <span className="visually-hidden">Status: </span>
             {toPascalCase(jobItem.status)}
           </div>
           <div className={style.updatedInfo}>

--- a/tdei-ui/src/components/ProjectAutocomplete/ProjectAutocomplete.js
+++ b/tdei-ui/src/components/ProjectAutocomplete/ProjectAutocomplete.js
@@ -13,9 +13,12 @@ const ProjectAutocomplete = ({ selectedProjectGroupId, projectSearchText, setPro
   const { loading, projectGroupList, hasMore } = useGetProjectGroup(debouncedValue, pageNo);
   const [selectedProjectGroup, setSelectedProjectGroup] = useState(null);
   const [showDropdown, setShowDropdown] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [announcement, setAnnouncement] = useState("");
 
   const observer = useRef();
   const autocompleteRef = useRef();
+  const listRef = useRef();
 
   const debouncedSearch = useMemo(
     () =>
@@ -43,7 +46,38 @@ const ProjectAutocomplete = ({ selectedProjectGroupId, projectSearchText, setPro
     }
     debouncedSearch(value);
     setShowDropdown(true);
+    setHighlightedIndex(-1);
   }
+
+  const handleKeyDown = (e) => {
+    if (!showDropdown || deduplicatedProjectGroups.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        prev < deduplicatedProjectGroups.length - 1 ? prev + 1 : prev
+      );
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (highlightedIndex >= 0 && highlightedIndex < deduplicatedProjectGroups.length) {
+        handleSelect(deduplicatedProjectGroups[highlightedIndex]);
+      }
+    } else if (e.key === "Escape" || e.key === "Tab") {
+      if (e.key === "Tab") e.preventDefault();
+      setShowDropdown(false);
+      setHighlightedIndex(-1);
+    }
+  };
+
+  // Scroll highlighted item into view AFTER render
+  useEffect(() => {
+    if (highlightedIndex >= 0 && listRef.current) {
+      const item = listRef.current.children[highlightedIndex];
+      if (item) item.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlightedIndex]);
 
   const deduplicatedProjectGroups = useMemo(() => {
     const seen = new Set();
@@ -55,6 +89,21 @@ const ProjectAutocomplete = ({ selectedProjectGroupId, projectSearchText, setPro
       return true;
     });
   }, [projectGroupList]);
+
+  // Announce result count to screen readers when dropdown opens
+  useEffect(() => {
+    if (showDropdown && !loading && deduplicatedProjectGroups.length > 0) {
+      setAnnouncement(
+        `${deduplicatedProjectGroups.length} result${
+          deduplicatedProjectGroups.length === 1 ? "" : "s"
+        } available. Use arrow keys to navigate.`
+      );
+    } else if (showDropdown && !loading && deduplicatedProjectGroups.length === 0) {
+      setAnnouncement("No project groups found.");
+    } else {
+      setAnnouncement("");
+    }
+  }, [showDropdown, loading, deduplicatedProjectGroups.length]);
 
   const lastProjectGroup = useCallback(
     (node) => {
@@ -72,8 +121,9 @@ const ProjectAutocomplete = ({ selectedProjectGroupId, projectSearchText, setPro
 
   const handleSelect = (projectGroup) => {
     setSelectedProjectGroup(projectGroup);
-    setProjectSearchText(projectGroup.project_group_name)
+    setProjectSearchText(projectGroup.project_group_name);
     setShowDropdown(false);
+    setHighlightedIndex(-1);
     onSelectProjectGroup(projectGroup.tdei_project_group_id);
   };
 
@@ -94,8 +144,25 @@ const ProjectAutocomplete = ({ selectedProjectGroupId, projectSearchText, setPro
     };
   }, [handleClickOutside, debouncedSearch]);
 
+  const listboxId = "project-group-listbox";
+  const activeDescendant =
+    highlightedIndex >= 0 && deduplicatedProjectGroups[highlightedIndex]
+      ? `pg-option-${deduplicatedProjectGroups[highlightedIndex].tdei_project_group_id}`
+      : undefined;
+  const isExpanded = showDropdown && deduplicatedProjectGroups.length > 0;
+
   return (
     <div className={styles.autocompleteContainer} ref={autocompleteRef}>
+      {/* Live region — screen readers announce results count */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{ position: "absolute", width: "1px", height: "1px", overflow: "hidden", clip: "rect(0,0,0,0)", whiteSpace: "nowrap" }}
+      >
+        {announcement}
+      </div>
+
       <InputGroup>
         <Form.Control
           type="text"
@@ -104,45 +171,54 @@ const ProjectAutocomplete = ({ selectedProjectGroupId, projectSearchText, setPro
           onChange={handleInputChange}
           value={selectedProjectGroup && selectedProjectGroupId ? selectedProjectGroup.project_group_name : projectSearchText}
           onFocus={() => setShowDropdown(true)}
+          onKeyDown={handleKeyDown}
           autoComplete="off"
-        />  
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded={isExpanded}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={activeDescendant}
+          aria-label="Search Project Group"
+        />
         {loading && (
           <InputGroup.Text>
-            <Spinner animation="border" size="sm" />
+            <Spinner animation="border" size="sm" aria-label="Loading results" />
           </InputGroup.Text>
         )}
       </InputGroup>
+
       {showDropdown && deduplicatedProjectGroups.length > 0 && (
-        <div className={styles.dropdownList}>
+        <div
+          role="listbox"
+          id={listboxId}
+          aria-label="Project Groups"
+          className={styles.dropdownList}
+          ref={listRef}
+          tabIndex="-1"
+        >
           {deduplicatedProjectGroups.map((group, index) => {
-            if (deduplicatedProjectGroups.length === index + 1) {
-              return (
-                <div
-                  key={group.tdei_project_group_id}
-                  id={group.tdei_project_group_id}
-                  className={`${styles.dropdownItem} ${
-                    selectedProjectGroup?.tdei_project_group_id === group.tdei_project_group_id ? styles.active : ""
-                  }`}
-                  onClick={() => handleSelect(group)}
-                  ref={lastProjectGroup}
-                >
-                  {group.project_group_name}
-                </div>
-              );
-            } else {
-              return (
-                <div
-                  key={group.tdei_project_group_id}
-                  id={group.tdei_project_group_id}
-                  className={`${styles.dropdownItem} ${
-                    selectedProjectGroup?.tdei_project_group_id === group.tdei_project_group_id ? styles.active : ""
-                  }`}
-                  onClick={() => handleSelect(group)}
-                >
-                  {group.project_group_name}
-                </div>
-              );
-            }
+            const optionId = `pg-option-${group.tdei_project_group_id}`;
+            const isSelected = selectedProjectGroup?.tdei_project_group_id === group.tdei_project_group_id;
+            return (
+              <div
+                key={group.tdei_project_group_id}
+                id={optionId}
+                role="option"
+                aria-selected={isSelected}
+                className={`${styles.dropdownItem} ${
+                  highlightedIndex === index
+                    ? styles.highlighted
+                    : isSelected
+                    ? styles.active
+                    : ""
+                }`}
+                onClick={() => handleSelect(group)}
+                ref={deduplicatedProjectGroups.length === index + 1 ? lastProjectGroup : null}
+              >
+                {group.project_group_name}
+              </div>
+            );
           })}
           {loading && (
             <div className="d-flex justify-content-center my-2">
@@ -152,7 +228,7 @@ const ProjectAutocomplete = ({ selectedProjectGroupId, projectSearchText, setPro
         </div>
       )}
       {showDropdown && deduplicatedProjectGroups.length === 0 && !loading && (
-        <div className={styles.noResults}>No project groups found.</div>
+        <div className={styles.noResults} role="status">No project groups found.</div>
       )}
     </div>
   );

--- a/tdei-ui/src/components/ProjectAutocomplete/ProjectAutocomplete.module.css
+++ b/tdei-ui/src/components/ProjectAutocomplete/ProjectAutocomplete.module.css
@@ -1,33 +1,45 @@
 .autocompleteContainer {
-    position: relative;
-    width: 100%;
-  }
-  
-  .dropdownList {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    max-height: 200px;
-    overflow-y: auto;
-    border: 1px solid #ced4da;
-    border-top: none;
-    background-color: #fff;
-    z-index: 1000;
-  }
-  
-  .dropdownItem {
-    padding: 8px 12px;
-    cursor: pointer;
-  }
-  
-  .dropdownItem:hover,
-  .active {
-    background-color: #f8f9fa;
-  }
-  
-  .noResults {
-    padding: 8px 12px;
-    color: #6c757d;
-  }
-  
+  position: relative;
+  width: 100%;
+}
+
+.dropdownList {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #ced4da;
+  border-top: none;
+  background-color: #fff;
+  z-index: 1000;
+  /* prevent the scrollable container from receiving Tab focus */
+  outline: none;
+}
+
+.dropdownItem {
+  padding: 8px 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.dropdownItem:hover {
+  background-color: #f8f9fa;
+}
+
+.active {
+  background-color: #f8f9fa;
+}
+
+/* keyboard-navigated item — matches react-select focused option style */
+.highlighted,
+.highlighted:hover {
+  background-color: #deebff;
+  outline: none;
+}
+
+.noResults {
+  padding: 8px 12px;
+  color: #6c757d;
+}

--- a/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitch.js
+++ b/tdei-ui/src/components/ProjectGroupSwitcher/ProjectGroupSwitch.js
@@ -192,6 +192,7 @@ export const ListingBlock = ({ project, handleUpdateProject, isCurrent }) => {
           />
           <div>
             <div className={style.projectGroupName} title={name}>
+              <span className="visually-hidden">Project Group Name: </span>
               {name}
             </div>
           </div>

--- a/tdei-ui/src/components/ServiceAutocomplete/ServiceAutocomplete.js
+++ b/tdei-ui/src/components/ServiceAutocomplete/ServiceAutocomplete.js
@@ -12,9 +12,12 @@ const ServiceAutocomplete = ({ serviceSearchText, setServiceSearchText, onSelect
   const { loading, error, serviceList, hasMore, setPageNumber } = useGetAllServices(debouncedValue, isAdmin, service_type);
   const [selectedService, setSelectedService] = useState(null);
   const [showDropdown, setShowDropdown] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [announcement, setAnnouncement] = useState("");
   
   const observer = useRef();
   const autocompleteRef = useRef();
+  const listRef = useRef();
 
   const debouncedSearch = useMemo(
     () =>
@@ -46,7 +49,38 @@ const ServiceAutocomplete = ({ serviceSearchText, setServiceSearchText, onSelect
     }
     debouncedSearch(value);
     setShowDropdown(true);
+    setHighlightedIndex(-1);
   };
+
+  const handleKeyDown = (e) => {
+    if (!showDropdown || deduplicatedServiceItems.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        prev < deduplicatedServiceItems.length - 1 ? prev + 1 : prev
+      );
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (highlightedIndex >= 0 && highlightedIndex < deduplicatedServiceItems.length) {
+        handleSelect(deduplicatedServiceItems[highlightedIndex]);
+      }
+    } else if (e.key === "Escape" || e.key === "Tab") {
+      if (e.key === "Tab") e.preventDefault();
+      setShowDropdown(false);
+      setHighlightedIndex(-1);
+    }
+  };
+
+  // Scroll highlighted item into view AFTER render
+  useEffect(() => {
+    if (highlightedIndex >= 0 && listRef.current) {
+      const item = listRef.current.children[highlightedIndex];
+      if (item) item.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlightedIndex]);
 
   const deduplicatedServiceItems = useMemo(() => {
     const seen = new Set();
@@ -56,6 +90,21 @@ const ServiceAutocomplete = ({ serviceSearchText, setServiceSearchText, onSelect
       return true;
     });
   }, [serviceList]);
+
+  // Announce result count to screen readers when dropdown opens
+  useEffect(() => {
+    if (showDropdown && !loading && deduplicatedServiceItems.length > 0) {
+      setAnnouncement(
+        `${deduplicatedServiceItems.length} result${
+          deduplicatedServiceItems.length === 1 ? "" : "s"
+        } available. Use arrow keys to navigate.`
+      );
+    } else if (showDropdown && !loading && deduplicatedServiceItems.length === 0) {
+      setAnnouncement("No services found.");
+    } else {
+      setAnnouncement("");
+    }
+  }, [showDropdown, loading, deduplicatedServiceItems.length]);
 
   const lastServiceElementRef = useCallback((node) => {
     if (loading) return;
@@ -73,6 +122,7 @@ const ServiceAutocomplete = ({ serviceSearchText, setServiceSearchText, onSelect
     setSelectedService(service);
     setServiceSearchText(service.service_name);
     setShowDropdown(false);
+    setHighlightedIndex(-1);
     onSelectService(service.tdei_service_id);
   };
 
@@ -97,8 +147,25 @@ const ServiceAutocomplete = ({ serviceSearchText, setServiceSearchText, onSelect
     };
   }, [handleClickOutside, debouncedSearch]);
 
+  const listboxId = "service-listbox";
+  const activeDescendant =
+    highlightedIndex >= 0 && deduplicatedServiceItems[highlightedIndex]
+      ? `svc-option-${deduplicatedServiceItems[highlightedIndex].tdei_service_id}`
+      : undefined;
+  const isExpanded = showDropdown && deduplicatedServiceItems.length > 0;
+
   return (
     <div className={styles.autocompleteContainer} ref={autocompleteRef}>
+      {/* Live region — screen readers announce results count */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{ position: "absolute", width: "1px", height: "1px", overflow: "hidden", clip: "rect(0,0,0,0)", whiteSpace: "nowrap" }}
+      >
+        {announcement}
+      </div>
+
       <InputGroup>
         <Form.Control
           type="text"
@@ -107,32 +174,59 @@ const ServiceAutocomplete = ({ serviceSearchText, setServiceSearchText, onSelect
           onChange={handleInputChange}
           value={selectedService ? selectedService.service_name : serviceSearchText}
           onFocus={() => setShowDropdown(true)}
+          onKeyDown={handleKeyDown}
           autoComplete="off"
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded={isExpanded}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={activeDescendant}
+          aria-label="Search Service"
         />
         {loading && (
           <InputGroup.Text>
-            <Spinner animation="border" size="sm" />
+            <Spinner animation="border" size="sm" aria-label="Loading results" />
           </InputGroup.Text>
         )}
       </InputGroup>
+
       {showDropdown && deduplicatedServiceItems.length > 0 && (
-        <div className={styles.dropdownList}>
-          {deduplicatedServiceItems.map((service, index) => (
-            <div
-              key={service.tdei_service_id}
-              className={`${styles.dropdownItem} ${
-                selectedService?.tdei_service_id === service.tdei_service_id ? styles.active : ""
-              }`}
-              onClick={() => handleSelect(service)}
-              ref={deduplicatedServiceItems.length === index + 1 ? lastServiceElementRef : null}
-            >
-              {service.service_name}
-            </div>
-          ))}
+        <div
+          role="listbox"
+          id={listboxId}
+          aria-label="Services"
+          className={styles.dropdownList}
+          ref={listRef}
+          tabIndex="-1"
+        >
+          {deduplicatedServiceItems.map((service, index) => {
+            const optionId = `svc-option-${service.tdei_service_id}`;
+            const isSelected = selectedService?.tdei_service_id === service.tdei_service_id;
+            return (
+              <div
+                key={service.tdei_service_id}
+                id={optionId}
+                role="option"
+                aria-selected={isSelected}
+                className={`${styles.dropdownItem} ${
+                  highlightedIndex === index
+                    ? styles.highlighted
+                    : isSelected
+                    ? styles.active
+                    : ""
+                }`}
+                onClick={() => handleSelect(service)}
+                ref={deduplicatedServiceItems.length === index + 1 ? lastServiceElementRef : null}
+              >
+                {service.service_name}
+              </div>
+            );
+          })}
         </div>
       )}
       {showDropdown && deduplicatedServiceItems.length === 0 && !loading && (
-        <div className={styles.noResults}>No services found.</div>
+        <div className={styles.noResults} role="status">No services found.</div>
       )}
     </div>
   );

--- a/tdei-ui/src/components/ServiceAutocomplete/ServiceAutocomplete.module.css
+++ b/tdei-ui/src/components/ServiceAutocomplete/ServiceAutocomplete.module.css
@@ -14,16 +14,29 @@
   border-top: none;
   background-color: #fff;
   z-index: 1000;
+  /* prevent the scrollable container from receiving Tab focus */
+  outline: none;
 }
 
 .dropdownItem {
   padding: 8px 12px;
   cursor: pointer;
+  user-select: none;
 }
 
-.dropdownItem:hover,
+.dropdownItem:hover {
+  background-color: #f8f9fa;
+}
+
 .active {
   background-color: #f8f9fa;
+}
+
+/* keyboard-navigated item — matches react-select focused option style */
+.highlighted,
+.highlighted:hover {
+  background-color: #deebff;
+  outline: none;
 }
 
 .noResults {

--- a/tdei-ui/src/hooks/roles/useProjectGroupRoles.js
+++ b/tdei-ui/src/hooks/roles/useProjectGroupRoles.js
@@ -6,11 +6,11 @@ import { useAuth } from "../useAuth";
 function useGetProjectGroupRoles(queryText) {
   const { user } = useAuth();
   return useInfiniteQuery(
-    [GET_PROJECT_GROUP_ROLES, user?.userId,queryText],
-    ({ pageParam = 1 }) => getProjectGroupRoles(user?.userId, pageParam,queryText),
+    [GET_PROJECT_GROUP_ROLES, user?.userId, queryText],
+    ({ pageParam = 1 }) => getProjectGroupRoles(user?.userId, pageParam, queryText),
     {
       getNextPageParam: (lastPage) =>
-        lastPage.data.length === 10 ? lastPage.pageParam + 1 : undefined,
+        lastPage.data.length < 10 ? undefined : lastPage.pageParam + 1,
     }
   );
 }

--- a/tdei-ui/src/routes/Datasets/DatasetRow.js
+++ b/tdei-ui/src/routes/Datasets/DatasetRow.js
@@ -126,6 +126,7 @@ const DatasetRow = ({ dataset, onAction, isReleasedList }) => {
                   className={style.datasetTitle}
                   title={metadata.dataset_detail.name}
                 >
+                  <span className="visually-hidden">Dataset Name: </span>
                   {metadata.dataset_detail.name}{" "}
                 </span>
                 {project_group.data_viewer_allowed && data_viewer_allowed && (
@@ -170,41 +171,48 @@ const DatasetRow = ({ dataset, onAction, isReleasedList }) => {
                   <b>Uploaded at : </b> {updatedTime(uploaded_timestamp)}
                 </span>
                 <span className={style.verticalSeparator}></span>
-                <span className={style.version}>{dataset_detail.version}</span>
+                <span className={style.version}>
+                  <span className="visually-hidden">Version: </span>
+                  {dataset_detail.version}
+                </span>
               </div>
             </div>
           </div>
         </div>
         {!isReleasedList ? null : (
           <div className={style.datasetItem}>
-            <div className={style.mobileOnly}>Project Group</div>
+            <div className={style.mobileOnly} aria-hidden="true">Project Group</div>
             <div
               className={style.serviceName}
               title={dataset.project_group.name}
             >
+              <span className="visually-hidden">Project Group: </span>
               {dataset.project_group.name}
             </div>
           </div>
         )}
         <div className={style.datasetItem}>
-          <div className={style.mobileOnly}>Service Name</div>
+          <div className={style.mobileOnly} aria-hidden="true">Service Name</div>
           <div className={style.serviceName} title={service.name}>
+            <span className="visually-hidden">Service Name: </span>
             {service.name}
           </div>
         </div>
         <div className={style.datasetItem}>
-          <div className={style.mobileOnly}>Type</div>
+          <div className={style.mobileOnly} aria-hidden="true">Type</div>
           <div className={style.typeNameTransform}>
+            <span className="visually-hidden">Type: </span>
             {data_type === "Osw" ? "OSW" : data_type}
           </div>
         </div>
         {isReleasedList ? null : (
           <div className={`${style.datasetItem} ${style.itemCenterAlign}`}>
-            <div className={style.mobileOnly}>Status</div>
+            <div className={style.mobileOnly} aria-hidden="true">Status</div>
             <div
               className={style.statusContainer}
               style={{ backgroundColor: getStatusColor() }}
             >
+              <span className="visually-hidden">Status: </span>
               {status === "Publish" ? "Released" : status}
             </div>
           </div>

--- a/tdei-ui/src/routes/Datasets/DatasetTableHeader.js
+++ b/tdei-ui/src/routes/Datasets/DatasetTableHeader.js
@@ -4,7 +4,7 @@ import style from "./Datasets.module.css"
 
 const DatasetTableHeader = ({ isReleasedDataList }) => {
     return (
-        <Container className={style.datasetsTableHeaderRow} fluid>
+        <Container className={style.datasetsTableHeaderRow} fluid aria-hidden="true">
             <div className={style.datasetCardHeader}>
                 <div className={style.datasetHeaderItem}>
                     Dataset Name

--- a/tdei-ui/src/routes/Jobs/Jobs.js
+++ b/tdei-ui/src/routes/Jobs/Jobs.js
@@ -290,42 +290,62 @@ const Jobs = () => {
                         <div className={style.sortableHeader}>
                             Job Type
                             {sortConfig.key === 'job_type' && sortConfig.direction === 'ascending' ? (
-                                <ArrowDropUpIcon onClick={() => sortData('job_type')} className={style.sortIcon} />
+                                <button type="button" className={style.sortButton} onClick={() => sortData('job_type')} aria-label="Sort by job type">
+                                    <ArrowDropUpIcon className={style.sortIcon} />
+                                </button>
                             ) : (
-                                <ArrowDropDownIcon onClick={() => sortData('job_type')} className={style.sortIcon} />
+                                <button type="button" className={style.sortButton} onClick={() => sortData('job_type')} aria-label="Sort by job type">
+                                    <ArrowDropDownIcon className={style.sortIcon} />
+                                </button>
                             )}
                         </div>
                         <div className={style.sortableHeader}>
                             Job Id
                             {sortConfig.key === 'job_id' && sortConfig.direction === 'ascending' ? (
-                                <ArrowDropUpIcon onClick={() => sortData('job_id')} className={style.sortIcon} />
+                                <button type="button" className={style.sortButton} onClick={() => sortData('job_id')} aria-label="Sort by job id">
+                                    <ArrowDropUpIcon className={style.sortIcon} />
+                                </button>
                             ) : (
-                                <ArrowDropDownIcon onClick={() => sortData('job_id')} className={style.sortIcon} />
+                                <button type="button" className={style.sortButton} onClick={() => sortData('job_id')} aria-label="Sort by job id">
+                                    <ArrowDropDownIcon className={style.sortIcon} />
+                                </button>
                             )}
                         </div>
                         <div className={style.sortableHeader}>
                             Submitted By
                             {sortConfig.key === 'requested_by' && sortConfig.direction === 'ascending' ? (
-                                <ArrowDropUpIcon onClick={() => sortData('requested_by')} className={style.sortIcon} />
+                                <button type="button" className={style.sortButton} onClick={() => sortData('requested_by')} aria-label="Sort by submitted by">
+                                    <ArrowDropUpIcon className={style.sortIcon} />
+                                </button>
                             ) : (
-                                <ArrowDropDownIcon onClick={() => sortData('requested_by')} className={style.sortIcon} />
+                                <button type="button" className={style.sortButton} onClick={() => sortData('requested_by')} aria-label="Sort by submitted by">
+                                    <ArrowDropDownIcon className={style.sortIcon} />
+                                </button>
                             )}
                         </div>
                         <div>Message</div>
                         <div className={style.sortableHeader}>
                             Created On
                             {sortConfig.key === 'created_at' && sortConfig.direction === 'ascending' ? (
-                                <ArrowDropUpIcon onClick={() => sortData('created_at')} className={style.sortIcon} />
+                                <button type="button" className={style.sortButton} onClick={() => sortData('created_at')} aria-label="Sort by created on">
+                                    <ArrowDropUpIcon className={style.sortIcon} />
+                                </button>
                             ) : (
-                                <ArrowDropDownIcon onClick={() => sortData('created_at')} className={style.sortIcon} />
+                                <button type="button" className={style.sortButton} onClick={() => sortData('created_at')} aria-label="Sort by created on">
+                                    <ArrowDropDownIcon className={style.sortIcon} />
+                                </button>
                             )}
                         </div>
                         <div className={style.sortableHeader}>
                             Status
                             {sortConfig.key === 'status' && sortConfig.direction === 'ascending' ? (
-                                <ArrowDropUpIcon onClick={() => sortData('status')} className={style.sortIcon} />
+                                <button type="button" className={style.sortButton} onClick={() => sortData('status')} aria-label="Sort by status">
+                                    <ArrowDropUpIcon className={style.sortIcon} />
+                                </button>
                             ) : (
-                                <ArrowDropDownIcon onClick={() => sortData('status')} className={style.sortIcon} />
+                                <button type="button" className={style.sortButton} onClick={() => sortData('status')} aria-label="Sort by status">
+                                    <ArrowDropDownIcon className={style.sortIcon} />
+                                </button>
                             )}
                         </div>
                     </div>

--- a/tdei-ui/src/routes/Jobs/Jobs.module.css
+++ b/tdei-ui/src/routes/Jobs/Jobs.module.css
@@ -593,9 +593,13 @@
 }
 
 .sortableHeader {
-  cursor: pointer;
   display: flex;
   align-items: center;
+  .sortButton {
+    background: none;
+    border: none;
+    padding: 0;
+  }
 }
 
 .emailContentWrap {

--- a/tdei-ui/src/routes/Members/Members.js
+++ b/tdei-ui/src/routes/Members/Members.js
@@ -175,7 +175,7 @@ const Members = () => {
             style.gridContainer,
             isAdmin ? style.adminGrid : style.userGrid,
             style.userHeader
-          )}>
+          )} aria-hidden="true">
             <div>Name & Email Id</div>
             <div>Contact Number</div>
             {!user.isAdmin && <div>Roles</div>}
@@ -204,18 +204,25 @@ const Members = () => {
                     </div>
                     <div>
                       <div className={style.name}>
+                        <span className="visually-hidden">Name: </span>
                         {getUserName(list, list.user_id === user?.userId)}
                       </div>
-                      <div className={style.address}>{list.username}</div>
+                      <div className={style.address}>
+                        <span className="visually-hidden">Email: </span>
+                        {list.username}
+                      </div>
                     </div>
                   </div>
                   <div className={style.content}>
-                    <div className={style.mobileOnly}>Contact Number</div>
-                    <div>{formatPhoneNumber(list.phone) || '--'}</div>
+                    <div className={style.mobileOnly} aria-hidden="true">Contact Number</div>
+                    <div>
+                      <span className="visually-hidden">Contact Number: </span>
+                      {formatPhoneNumber(list.phone) || '--'}
+                    </div>
                   </div>
                   {!user.isAdmin && (
                     <div className={style.roles}>
-                      <div className={style.mobileOnly}>Roles</div>
+                      <div className={style.mobileOnly} aria-hidden="true">Roles</div>
                       <DisplayRolesList list={list} />
                     </div>
                   )}
@@ -318,11 +325,13 @@ const DisplayRolesList = ({ list }) => {
       {showMore
         ? list.roles.map((role) => (
           <div className={style.roleBlock} key={role}>
+            <span className="visually-hidden">Role: </span>
             {role}
           </div>
         ))
         : list.roles.slice(0, 2).map((role) => (
           <div className={style.roleBlock} key={role}>
+             <span className="visually-hidden">Role: </span>
             {role}
           </div>
         ))}

--- a/tdei-ui/src/routes/ProjectGroup/ProjectGroup.js
+++ b/tdei-ui/src/routes/ProjectGroup/ProjectGroup.js
@@ -197,7 +197,7 @@ const ProjectGroup = () => {
               }}
             />
           </div>
-          <div className={clsx(style.gridContainer, style.projectHeader)}>
+          <div className={clsx(style.gridContainer, style.projectHeader)} aria-hidden="true">
             <div>Name & Address</div>
             <div>URL</div>
             <div>Contact Number</div>
@@ -223,23 +223,27 @@ const ProjectGroup = () => {
                           className={style.name}
                           title={list.project_group_name}
                         >
+                          <span className="visually-hidden">Project Group Name: </span>
                           {list.project_group_name}
                         </div>
                         <div className={style.address}>
+                          <span className="visually-hidden">Address: </span>
                           {list.address}
                         </div>
                       </div>
                     </div>
                     <div className={style.content}>
-                      <div className={style.mobileOnly}>URL</div>
+                      <div className={style.mobileOnly} aria-hidden="true">URL</div>
+                      <span className="visually-hidden">URL: </span>
                       {list.url || `--`}
                     </div>
                     <div className={style.content}>
-                      <div className={style.mobileOnly}>Contact Number</div>
+                      <div className={style.mobileOnly} aria-hidden="true">Contact Number</div>
+                      <span className="visually-hidden">Contact Number: </span>
                       {list.phone || `--`}
                     </div>
                     <div className={style.content}>
-                      <div className={style.mobileOnly}>POC</div>
+                      <div className={style.mobileOnly} aria-hidden="true">POC</div>
                       <DisplayList list={list} handlePoc={handlePoc} />
                     </div>
                     <div className={style.actionItem}>
@@ -365,6 +369,7 @@ const DisplayList = ({ list, handlePoc }) => {
         <div className={style.pocList}>
           <img src={userIcon} className={style.pocUserIcon} alt="" />
           <div>
+            <span className="visually-hidden">POC: </span>
             {getUserName(poc[0])}
           </div>
           {poc.length > 1 ? (

--- a/tdei-ui/src/routes/Services/Services.js
+++ b/tdei-ui/src/routes/Services/Services.js
@@ -304,8 +304,14 @@ export const ListingBlock = ({ id, name, type, icon, handleEdit, handleUpdateSta
         <div className={style.names}>
           <img src={serviceTypeIcon} className={style.serviceTypeIcon} alt="" />
           <div>
-            <div className={style.serviceType}>{type}</div>
-            <div className={style.serviceName} title={name}>{name}</div>
+            <div className={style.serviceType}>
+              <span className="visually-hidden">Service Type: </span>
+              {type}
+            </div>
+            <div className={style.serviceName} title={name}>
+              <span className="visually-hidden">Service Name: </span>
+              {name}
+            </div>
           </div>
         </div>
         {isUserPoc || user?.isAdmin ? (<div className={style.buttons}>


### PR DESCRIPTION
## DevBoard Task :

https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3258

**Root cause:** The [getNextPageParam] logic used a strict equality check (`data.length === 10`) to determine if more pages exist. The `/project-group-roles/{userId}` API was returning more than 10 items per page (despite `page_size=10` being sent), causing `data.length === 10` to evaluate to `false` which told react-query there were no more pages, hiding the Load More button prematurely.

### Changes Implemented : 
- Changed to `data.length < 10 ? undefined : lastPage.pageParam + 1`, which correctly treats any partial page as the last page regardless of how many items the API returns per call.

### Impacted Areas for Testing 

| Area | Steps |
|---|---|
| **Project Group Switcher** | Load More button appears when >10 project groups exist; clicking it loads the next batch; disappears on the last page |
| **Project Group Switcher** | Searching filters results; Load More still works correctly with search active |

### Screenshots :
<img width="1470" height="798" alt="Screenshot 2026-03-20 at 5 44 28 PM" src="https://github.com/user-attachments/assets/976da9f1-7aed-446d-8668-a287774088f7" />

## DevBoard Task :

https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3270
Accessibility and keyboard navigation enhancements:

* Added keyboard navigation support (arrow keys, Enter, Escape, Tab) to all autocomplete dropdowns, allowing users to navigate and select items without a mouse. (`DatasetAutocomplete.js`, `ProjectAutocomplete.js`, `ServiceAutocomplete.js`) 
* Introduced ARIA attributes (`role="combobox"`, `aria-expanded`, `aria-controls`, `aria-activedescendant`, etc.) and live region announcements to all autocomplete inputs and dropdowns, improving screen reader support and accessibility compliance. (`DatasetAutocomplete.js`, `ProjectAutocomplete.js`, `ServiceAutocomplete.js`) 
* Added a visually highlighted style for keyboard-navigated dropdown items, matching accessibility best practices and improving user feedback. (`ProjectAutocomplete.module.css`)

### Impacted Areas for Testing 
| Area | Steps |
|---|---|
| ** Project Group field** | Type 3+ characters → screen reader announces result count → arrow keys navigate options → Enter selects → Escape closes |
| **Service field** | Same keyboard + screen reader flow as above |
| **Dataset field** | Same keyboard + screen reader flow; clear button announces label |
| **Screen reader (VoiceOver)** | All three autocomplete fields announce: expanded state, active option on arrow navigation, result count on load, no-results message |
| **Keyboard-only navigation** | Tab, Arrow Up/Down, Enter, Escape all work correctly in all three autocomplete fields without mouse |
### Screenshots :
<img width="1457" height="793" alt="Screenshot 2026-03-20 at 4 32 20 PM" src="https://github.com/user-attachments/assets/927a1a21-3841-49ac-acf1-2bd001f527f8" />
<img width="1454" height="800" alt="Screenshot 2026-03-20 at 4 32 42 PM" src="https://github.com/user-attachments/assets/4b1a4db8-fe2b-44fc-a89b-a72d451baa06" />
<img width="1470" height="798" alt="Screenshot 2026-03-20 at 6 07 03 PM" src="https://github.com/user-attachments/assets/7ee77b58-4a65-4cd6-b459-69d239af71b3" />

- Added screen reader elements to all table-structured layouts to provide more meaningful context for assistive technologies
- Converted sorting actions into buttons to ensure proper keyboard accessibility and interaction
- Removed redundant mobile UI labels where they duplicated screen reader text, reducing noise for assistive users