### PR TITLE
Task 3106 - Add formatTypeLabel and standardize type labels

### DIFF
--- a/tdei-ui/src/components/JobListItem/JobListItem.js
+++ b/tdei-ui/src/components/JobListItem/JobListItem.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import style from "../../routes/Jobs/Jobs.module.css";
 import ShowJobMessageModal from "../ShowJobMessage/ShowJobMessageModal";
 import JobMsgDescModal from "../ShowJobMessage/JobMsgDescModal";
-import { toPascalCase } from "../../utils";
+import { formatTypeLabel, toPascalCase } from "../../utils";
 import useDownloadJob from "../../hooks/jobs/useDownloadJob";
 import ResponseToast from "../ToastMessage/ResponseToast";
 import JobInputDescModal from "../ShowJobMessage/JobInputDescModal";
@@ -102,11 +102,7 @@ const JobListItem = ({ jobItem }) => {
 
   const getJobStatusTitle = () => {
     let dataType = jobItem.data_type || "";
-    if (dataType === "osw") {
-      dataType = dataType.toUpperCase();
-    } else {
-      dataType = toPascalCase(dataType);
-    }
+    dataType = formatTypeLabel(dataType);
     let jobType = jobItem.job_type ? jobItem.job_type.replace(/-/g, " ") : "";
     if (jobItem.request_input?.dataset_name) {
       return jobItem.request_input.dataset_name;

--- a/tdei-ui/src/components/ProjectGroupList/CustomDropdown.js
+++ b/tdei-ui/src/components/ProjectGroupList/CustomDropdown.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import clsx from "clsx";
-import { toPascalCase } from "../../utils";
+import { formatTypeLabel } from "../../utils";
 import style from "./Dropdown.module.css";
 
 const Icon = () => {
@@ -89,7 +89,7 @@ const CustomDropdown = ({
           className={style.dropdownInput}
         >
           <div className={style.dropdownSelectedValue}>
-            {getDisplay() == "osw" ? "OSW" : toPascalCase(getDisplay())}
+            {formatTypeLabel(getDisplay())}
           </div>
           <div className={style.dropdownTools}>
             <div className={style.dropdownTool}>
@@ -113,7 +113,7 @@ const CustomDropdown = ({
                   })}
                   tabIndex="0"
                 >
-                  {optionDisplayMap[option] || (option == "osw" ? "OSW" : toPascalCase(option))}
+                  {optionDisplayMap[option] || formatTypeLabel(option)}
                 </a>
               ))}
             </div>

--- a/tdei-ui/src/routes/Datasets/DatasetRow.js
+++ b/tdei-ui/src/routes/Datasets/DatasetRow.js
@@ -6,7 +6,7 @@ import openDataViewerIcon from "../../assets/img/action-open-console.svg";
 import { workspaceUrl } from "../../services";
 import DatasetsActions from "./DatasetsActions";
 import ClipboardCopy from "../Services/ClipBoardCopy";
-import { updatedTime } from "../../utils";
+import { formatTypeLabel, updatedTime } from "../../utils";
 import { useDispatch, useSelector } from "react-redux";
 import { show } from "../../store/notificationModal.slice";
 import useIsPoc from "../../hooks/useIsPoc";
@@ -202,7 +202,7 @@ const DatasetRow = ({ dataset, onAction, isReleasedList }) => {
           <div className={style.mobileOnly} aria-hidden="true">Type</div>
           <div className={style.typeNameTransform}>
             <span className="visually-hidden">Type: </span>
-            {data_type === "Osw" ? "OSW" : data_type}
+            {formatTypeLabel(data_type)}
           </div>
         </div>
         {isReleasedList ? null : (

--- a/tdei-ui/src/routes/Services/CreateUpdateService.js
+++ b/tdei-ui/src/routes/Services/CreateUpdateService.js
@@ -18,7 +18,7 @@ import { GEOJSON } from '../../utils'
 import { GET_SERVICES } from "../../utils";
 import { getService } from "../../services";
 import ServiceTypeDropdownForm from "./ServiceTypeDropdownForm";
-import { toPascalCase } from "../../utils";
+import { formatTypeLabel } from "../../utils";
 import ResponseToast from "../../components/ToastMessage/ResponseToast";
 
 const CreateUpdateService = () => {
@@ -236,7 +236,7 @@ const CreateUpdateService = () => {
                                             type="text"
                                             placeholder="Select Service Type"
                                             name="service_type"
-                                            value={idData['serviceType'] === "" ? toPascalCase(values.service_type) : toPascalCase(idData['serviceType'])}
+                                            value={formatTypeLabel(idData['serviceType'] === "" ? values.service_type : idData['serviceType'])}
                                             onChange={handleChange}
                                             onBlur={handleBlur}
                                             readOnly

--- a/tdei-ui/src/routes/Services/Services.js
+++ b/tdei-ui/src/routes/Services/Services.js
@@ -30,7 +30,7 @@ import useIsPoc from "../../hooks/useIsPoc";
 import InputGroup from 'react-bootstrap/InputGroup';
 import { Dropdown } from 'react-bootstrap';
 import DropdownButton from 'react-bootstrap/DropdownButton';
-import { toPascalCase } from "../../utils";
+import { formatTypeLabel } from "../../utils";
 import Select from 'react-select';
 import useEditServiceStatus from "../../hooks/service/useEditServiceStatus";
 import CustomModal from "../../components/SuccessModal/CustomModal";
@@ -180,13 +180,13 @@ const Services = () => {
           <InputGroup className="mb-3">
             <Dropdown onSelect={handleSelect} align="end" className={style.dropdownButton}>
               <Dropdown.Toggle variant="outline-secondary customBorderColor" id="input-group-dropdown-2" aria-label="Select Service Type">
-                {serviceType ? toPascalCase(serviceType) : ''}
+                {serviceType ? formatTypeLabel(serviceType) : ''}
               </Dropdown.Toggle>
               <Dropdown.Menu role="listbox">
                 <Dropdown.Item as="button" role="option" aria-selected={serviceType === ""} eventKey="">All</Dropdown.Item>
                 <Dropdown.Item as="button" role="option" aria-selected={serviceType === "flex"} eventKey="flex">Flex</Dropdown.Item>
                 <Dropdown.Item as="button" role="option" aria-selected={serviceType === "pathways"} eventKey="pathways">Pathways</Dropdown.Item>
-                <Dropdown.Item as="button" role="option" aria-selected={serviceType === "osw"} eventKey="osw">Osw</Dropdown.Item>
+                <Dropdown.Item as="button" role="option" aria-selected={serviceType === "osw"} eventKey="osw">OSW</Dropdown.Item>
               </Dropdown.Menu>
             </Dropdown>
             <label htmlFor="search-service-input" className="visually-hidden">Search Service</label>
@@ -306,7 +306,7 @@ export const ListingBlock = ({ id, name, type, icon, handleEdit, handleUpdateSta
           <div>
             <div className={style.serviceType}>
               <span className="visually-hidden">Service Type: </span>
-              {type}
+              {formatTypeLabel(type)}
             </div>
             <div className={style.serviceName} title={name}>
               <span className="visually-hidden">Service Name: </span>

--- a/tdei-ui/src/routes/UploadDataset/MetaDataForm/DropdownComponents/DataTypeDropdown.js
+++ b/tdei-ui/src/routes/UploadDataset/MetaDataForm/DropdownComponents/DataTypeDropdown.js
@@ -1,13 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import FormControl from '@mui/material/FormControl';
 import Select from 'react-select';
+import { formatTypeLabel } from "../../../../utils/helper";
 
 const DataTypeDropdownForm = ({ field, form, onChange, formDataDatasetType }) => {
 
   const options = [
-    { value: 'flex', label: 'flex' },
-    { value: 'pathways', label: 'pathways' },
-    { value: 'osw', label: 'osw' },
+    { value: 'flex', label: formatTypeLabel('flex') },
+    { value: 'pathways', label: formatTypeLabel('pathways') },
+    { value: 'osw', label: formatTypeLabel('osw') },
   ];
   
   const [currentValue, setCurrentValue] = useState(null);

--- a/tdei-ui/src/routes/UploadDataset/ServiceUpload.js
+++ b/tdei-ui/src/routes/UploadDataset/ServiceUpload.js
@@ -54,7 +54,7 @@ const ServiceUpload = ({ selectedData, onSelectedServiceChange, dataset, fromClo
   const options = [
     { value: 'flex', label: 'Flex' },
     { value: 'pathways', label: 'Pathways' },
-    { value: 'osw', label: 'Osw' },
+    { value: 'osw', label: 'OSW' },
   ];
 
   return (

--- a/tdei-ui/src/routes/UploadDataset/ServicesList.js
+++ b/tdei-ui/src/routes/UploadDataset/ServicesList.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styles from "./UploadDataset.module.css";
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
-import { toPascalCase } from "../../utils";
+import { formatTypeLabel } from "../../utils";
 
 function ServicesList({ id, name, isSelected, serviceType, handleSelectedService }) {
     return (
@@ -16,7 +16,7 @@ function ServicesList({ id, name, isSelected, serviceType, handleSelectedService
             <span style={{ marginLeft: "10px" }}>{name}</span>
             <div className={styles.serviceTypeContainer}>
                 <span className={styles.divider}>|</span>
-                <span className={styles.serviceType}>{toPascalCase(serviceType)}</span>
+                <span className={styles.serviceType}>{formatTypeLabel(serviceType)}</span>
             </div>
 
         </button>

--- a/tdei-ui/src/utils/helper.js
+++ b/tdei-ui/src/utils/helper.js
@@ -17,6 +17,16 @@ export const toPascalCase = (str) => {
     });
 };
 
+export const formatTypeLabel = (value) => {
+  if (!value) return "";
+
+  const normalizedValue = String(value).toLowerCase();
+  if (normalizedValue === "osw") {
+    return "OSW";
+  }
+  return toPascalCase(String(value));
+};
+
 export const formatDate = (value) => {
   let date = new Date(value);
   const day = date.toLocaleString('default', { day: '2-digit' });


### PR DESCRIPTION
## DevBoard Task : 
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3106

### Changes Implemented : 

**Label Formatting Standardization:**

* Added a new `formatTypeLabel` utility function in `utils/helper.js` to format type labels consistently, returning "OSW" for "osw" and using PascalCase for other values.
* Replaced `toPascalCase` with `formatTypeLabel` across multiple components and routes, including `JobListItem.js`, `CustomDropdown.js`, `DatasetRow.js`, `CreateUpdateService.js`, `Services.js`, `ServicesList.js`, and related dropdowns and forms.

**Dropdown and Option Label Improvements:**

* Updated dropdown option labels and values to use `formatTypeLabel`, ensuring "OSW" is displayed in uppercase and other types in PascalCase. 

### Screenshots :
<img width="1470" height="804" alt="Screenshot 2026-04-16 at 12 20 23 PM" src="https://github.com/user-attachments/assets/50e2004c-7b8a-44aa-b431-91cc55a4f801" />
<img width="1469" height="800" alt="Screenshot 2026-04-16 at 12 20 43 PM" src="https://github.com/user-attachments/assets/428fe54e-f281-43c4-8e9d-458f09de62a7" />
<img width="1470" height="802" alt="Screenshot 2026-04-16 at 12 21 03 PM" src="https://github.com/user-attachments/assets/754d77b5-ce6e-4a10-a44c-a95ce1a1421b" />
