### PR TITLE
Task-3544 : Tweak referral header copy and punctuation

### DIFF
--- a/tdei-ui/src/routes/Referral/CreateUpdateReferralCode.js
+++ b/tdei-ui/src/routes/Referral/CreateUpdateReferralCode.js
@@ -126,12 +126,12 @@ const CreateUpdateReferralCode = () => {
   const headerSubtitle = editing
     ? (
       <>
-        You’re editing a referral code in project group — <span className="fw-bold">{groupName}</span>.
+        You’re editing a referral code in project group <span className="fw-bold">{groupName}</span>.
       </>
     )
     : (
       <>
-        You’re creating a referral code in project group — <span className="fw-bold">{groupName}</span>.
+        You’re creating a referral code in project group <span className="fw-bold">{groupName}</span>.
       </>
     );
 

--- a/tdei-ui/src/routes/Referral/Referral.js
+++ b/tdei-ui/src/routes/Referral/Referral.js
@@ -178,7 +178,7 @@ const Referral = () => {
             <div>
               <h2 className="page-header-title">Referral Codes</h2>
               <div className="page-header-subtitle">
-                Manage and track your referral and invite codes of project group –{" "}
+                Manage and track your referral and invite codes for project group{" "}
                 <span className="fw-bold">
                   {pgLoading ? "…" : (projectGroup?.project_group_name || "—")}
                 </span>.


### PR DESCRIPTION
## DevBoard Task : 
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3544/

### Changes Implemented : 
Adjust header text in referral components for readability and consistency: remove em/en-dashes and extra spacing around project group name, and change "of" to "for" in the Referral page. Changes applied to CreateUpdateReferralCode.js and Referral.js.

### Screenshots:
<img width="1466" height="796" alt="Screenshot 2026-04-20 at 1 03 58 PM" src="https://github.com/user-attachments/assets/394b0c11-ca1d-452e-af59-5ed9f037693c" />
<img width="1469" height="798" alt="Screenshot 2026-04-20 at 1 04 22 PM" src="https://github.com/user-attachments/assets/f0ba6470-0884-4c1a-a4fe-b94a3e77708d" />
