### PR TITLE
Feature task 3560 filters change

### DIFF
--- a/tdei-ui/src/routes/Datasets/Datasets.module.css
+++ b/tdei-ui/src/routes/Datasets/Datasets.module.css
@@ -385,10 +385,12 @@
   align-items: center;
   gap: 15px;
   .primaryFilterBlock {
-    width: 240px;
+    flex: 1 1 0;
+    min-width: 0;
   }
   .primaryFilterBlock_Released {
-    width: 240px;
+    flex: 1 1 0;
+    min-width: 0;
   }
 }
 .secondaryFilterContainer {
@@ -465,11 +467,15 @@
     }
   }
   .primaryFilterContainer {
+    flex-direction: column;
+    align-items: stretch;
     .primaryFilterBlock {
       width: 100%;
+      flex: none;
     }
     .primaryFilterBlock_Released {
-      width: 50%;
+      width: 100%;
+      flex: none;
     }
   }
   .secondaryFilterContainer {
@@ -515,4 +521,3 @@
     }
   }
 }
-

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -563,29 +563,54 @@ const MyDatasets = () => {
                   </Form.Group>
                 </Col>
               )}
-              <Col md={4} className={style.datasetFilterBlock}>
-                <Form.Group>
-                  <div className={style.labelWithClear}>
-                    <Form.Label htmlFor="service-search">Service</Form.Label>
-                    <button
-                      type="button"
-                      className={style.clearButton}
-                      onClick={handleClearService}
-                      aria-label="Clear service search"
-                    >
-                      Clear
-                    </button>
-                  </div>
-                  <ServiceAutocomplete
-                    serviceSearchText={serviceSearchText}
-                    setServiceSearchText={setServiceSearchText}
-                    onSelectService={handleServiceSelect}
-                    isAdmin={user && user.isAdmin}
-                  />
-                </Form.Group>
-              </Col>
+              {!isAdmin && (
+                <Col md={4} className={style.datasetFilterBlock}>
+                  <Form.Group>
+                    <div className={style.labelWithClear}>
+                      <Form.Label htmlFor="service-search">Service</Form.Label>
+                      <button
+                        type="button"
+                        className={style.clearButton}
+                        onClick={handleClearService}
+                        aria-label="Clear service search"
+                      >
+                        Clear
+                      </button>
+                    </div>
+                    <ServiceAutocomplete
+                      serviceSearchText={serviceSearchText}
+                      setServiceSearchText={setServiceSearchText}
+                      onSelectService={handleServiceSelect}
+                      isAdmin={user && user.isAdmin}
+                    />
+                  </Form.Group>
+                </Col>
+              )}
             </Row>
             <Row className="">
+              {isAdmin && (
+                <Col md={4} className={style.datasetFilterBlock}>
+                  <Form.Group>
+                    <div className={style.labelWithClear}>
+                      <Form.Label htmlFor="service-search">Service</Form.Label>
+                      <button
+                        type="button"
+                        className={style.clearButton}
+                        onClick={handleClearService}
+                        aria-label="Clear service search"
+                      >
+                        Clear
+                      </button>
+                    </div>
+                    <ServiceAutocomplete
+                      serviceSearchText={serviceSearchText}
+                      setServiceSearchText={setServiceSearchText}
+                      onSelectService={handleServiceSelect}
+                      isAdmin={user && user.isAdmin}
+                    />
+                  </Form.Group>
+                </Col>
+              )}
               <Col md={4} className={style.datasetFilterBlock}>
                 <div className={style.labelWithClear}>
                   <Form.Label htmlFor="valid-from">Valid From</Form.Label>

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -441,35 +441,63 @@ const MyDatasets = () => {
     <div>
       <Form noValidate>
         <Row className="my-3 gx-0">
-          <Col md={12} lg={6}>
+          <Col md={12} lg={8}>
             <Form.Group className={style.primaryFilterContainer}>
               <div className={style.primaryFilterBlock}>
-                <Form.Label htmlFor="type-filter">Type</Form.Label>
-                <Select
-                  inputId="type-filter"
-                  isSearchable={false}
-                  defaultValue={{ label: "All", value: "" }}
-                  onChange={handleSelectedDataType}
-                  options={options}
-                  components={{ IndicatorSeparator: () => null }}
-                  aria-label="Filter by Type"
+                <div className={style.labelWithClear}>
+                  <Form.Label htmlFor="dataset-search">Dataset</Form.Label>
+                  <button
+                    type="button"
+                    className={style.clearButton}
+                    onClick={() => {
+                      setQuery("");
+                      debouncedHandleSearch({ target: { value: "" } });
+                    }}
+                    aria-label="Clear dataset search"
+                  >
+                    Clear
+                  </button>
+                </div>
+                <Form.Control
+                  id="dataset-search"
+                  value={query}
+                  aria-label="Search Dataset"
+                  placeholder="Search Dataset"
+                  onChange={(e) => {
+                    setQuery(e.target.value);
+                    debouncedHandleSearch(e);
+                  }}
                 />
               </div>
               <div className={style.primaryFilterBlock}>
-                <Form.Label htmlFor="status-filter">Status</Form.Label>
-                <Select
-                  inputId="status-filter"
-                  isSearchable={false}
-                  defaultValue={{ label: "All", value: "All" }}
-                  onChange={handleSelectedStatus}
-                  options={statusOptions}
-                  components={{ IndicatorSeparator: () => null }}
-                  aria-label="Filter by Status"
+                <div className={style.labelWithClear}>
+                  <Form.Label htmlFor="dataset-id-search-primary">Dataset ID</Form.Label>
+                  <button
+                    type="button"
+                    className={style.clearButton}
+                    onClick={() => {
+                      setDatasetIdQuery("");
+                      handleDatasetIdSearch({ target: { value: "" } });
+                    }}
+                    aria-label="Clear dataset ID search"
+                  >
+                    Clear
+                  </button>
+                </div>
+                <Form.Control
+                  id="dataset-id-search-primary"
+                  aria-label="Search Dataset ID"
+                  placeholder="Search Dataset ID"
+                  value={datasetIdQuery}
+                  onChange={(e) => {
+                    setDatasetIdQuery(e.target.value);
+                    debouncedHandleDatasetIdSearch(e);
+                  }}
                 />
               </div>
             </Form.Group>
           </Col>
-          <Col md={12} lg={6}>
+          <Col md={12} lg={4}>
             <SortRefreshComponent
               handleRefresh={handleRefresh}
               handleSortChange={handleSortChange}
@@ -484,33 +512,33 @@ const MyDatasets = () => {
             <Row className="mb-3">
               <Col md={4} className={style.datasetFilterBlock}>
                 <Form.Group>
-                  <div className={style.labelWithClear}>
-                    <Form.Label htmlFor="dataset-search">Dataset</Form.Label>
-                    <button
-                      type="button"
-                      className={style.clearButton}
-                      onClick={() => {
-                        setQuery("");
-                        debouncedHandleSearch({ target: { value: "" } });
-                      }}
-                      aria-label="Clear dataset search"
-                    >
-                      Clear
-                    </button>
-                  </div>
-                  <Form.Control
-                    id="dataset-search"
-                    value={query}
-                    aria-label="Search Dataset"
-                    placeholder="Search Dataset"
-                    onChange={(e) => {
-                      setQuery(e.target.value);
-                      debouncedHandleSearch(e);
-                    }}
+                  <Form.Label htmlFor="type-filter">Type</Form.Label>
+                  <Select
+                    inputId="type-filter"
+                    isSearchable={false}
+                    defaultValue={{ label: "All", value: "" }}
+                    onChange={handleSelectedDataType}
+                    options={options}
+                    components={{ IndicatorSeparator: () => null }}
+                    aria-label="Filter by Type"
                   />
                 </Form.Group>
               </Col>
-              {isAdmin ? (
+              <Col md={4} className={style.datasetFilterBlock}>
+                <Form.Group>
+                  <Form.Label htmlFor="status-filter">Status</Form.Label>
+                  <Select
+                    inputId="status-filter"
+                    isSearchable={false}
+                    defaultValue={{ label: "All", value: "All" }}
+                    onChange={handleSelectedStatus}
+                    options={statusOptions}
+                    components={{ IndicatorSeparator: () => null }}
+                    aria-label="Filter by Status"
+                  />
+                </Form.Group>
+              </Col>
+              {isAdmin && (
                 <Col md={4} className={style.datasetFilterBlock}>
                   <Form.Group>
                     <div className={style.labelWithClear}>
@@ -531,35 +559,6 @@ const MyDatasets = () => {
                       onSelectProjectGroup={(projectGroupId) =>
                         setSelectedProjectGroupId(projectGroupId)
                       }
-                    />
-                  </Form.Group>
-                </Col>
-              ) : (
-                <Col md={4} className={style.datasetFilterBlock}>
-                  <Form.Group>
-                    <div className={style.labelWithClear}>
-                      <Form.Label htmlFor="datasetId-search">Dataset ID</Form.Label>
-                      <button
-                        type="button"
-                        className={style.clearButton}
-                        onClick={() => {
-                          setDatasetIdQuery("");
-                          handleDatasetIdSearch({ target: { value: "" } });
-                        }}
-                        aria-label="Clear dataset ID search"
-                      >
-                        Clear
-                      </button>
-                    </div>
-                    <Form.Control
-                      id="datasetId-search"
-                      aria-label="Search Dataset ID"
-                      placeholder="Search Dataset ID"
-                      value={datasetIdQuery}
-                      onChange={(e) => {
-                        setDatasetIdQuery(e.target.value);
-                        debouncedHandleDatasetIdSearch(e);
-                      }}
                     />
                   </Form.Group>
                 </Col>
@@ -587,36 +586,6 @@ const MyDatasets = () => {
               </Col>
             </Row>
             <Row className="">
-              {isAdmin && (
-                <Col md={4} className={style.datasetFilterBlock}>
-                  <Form.Group>
-                    <div className={style.labelWithClear}>
-                      <Form.Label htmlFor="dataset-id-search">Dataset ID</Form.Label>
-                      <button
-                        type="button"
-                        className={style.clearButton}
-                        onClick={() => {
-                          setDatasetIdQuery("");
-                          handleDatasetIdSearch({ target: { value: "" } });
-                        }}
-                        aria-label="Clear dataset ID search"
-                      >
-                        Clear
-                      </button>
-                    </div>
-                    <Form.Control
-                      id="dataset-id-search"
-                      aria-label="Search Dataset ID"
-                      placeholder="Search Dataset ID"
-                      value={datasetIdQuery}
-                      onChange={(e) => {
-                        setDatasetIdQuery(e.target.value);
-                        debouncedHandleDatasetIdSearch(e);
-                      }}
-                    />
-                  </Form.Group>
-                </Col>
-              )}
               <Col md={4} className={style.datasetFilterBlock}>
                 <div className={style.labelWithClear}>
                   <Form.Label htmlFor="valid-from">Valid From</Form.Label>

--- a/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
+++ b/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
@@ -281,23 +281,63 @@ const ReleasedDatasets = () => {
     <div>
       <Form noValidate>
         <Row className="my-3 gx-0">
-          <Col md={12} lg={6}>
+          <Col md={12} lg={8}>
             <Form.Group className={style.primaryFilterContainer}>
               <div className={style.primaryFilterBlock_Released}>
-                <Form.Label htmlFor="type-filter">Type</Form.Label>
-                <Select
-                  inputId='type-filter'
-                  isSearchable={false}
-                  defaultValue={{ label: "All", value: "" }}
-                  onChange={handleSelectedDataType}
-                  options={options}
-                  components={{ IndicatorSeparator: () => null }}
-                  aria-label='Filter by Type'
+                <div className={style.labelWithClear}>
+                  <Form.Label htmlFor="dataset-search">Dataset</Form.Label>
+                  <button
+                    type="button"
+                    className={style.clearButton}
+                    onClick={() => {
+                      setQuery("");
+                      debouncedHandleSearch({ target: { value: "" } });
+                    }}
+                    aria-label="Clear dataset search"
+                  >
+                    Clear
+                  </button>
+                </div>
+                <Form.Control
+                  id='dataset-search'
+                  value={query}
+                  aria-label="Search Dataset"
+                  placeholder="Search Dataset"
+                  onChange={(e) => {
+                    setQuery(e.target.value);
+                    debouncedHandleSearch(e);
+                  }}
+                />
+              </div>
+              <div className={style.primaryFilterBlock_Released}>
+                <div className={style.labelWithClear}>
+                  <Form.Label htmlFor="dataset-id-search-primary">Dataset ID</Form.Label>
+                  <button
+                    type="button"
+                    className={style.clearButton}
+                    onClick={() => {
+                      setDatasetIdQuery("");
+                      handleDatasetIdSearch({ target: { value: "" } });
+                    }}
+                    aria-label="Clear dataset ID search"
+                  >
+                    Clear
+                  </button>
+                </div>
+                <Form.Control
+                  id='dataset-id-search-primary'
+                  aria-label="Search Dataset ID"
+                  placeholder="Search Dataset ID"
+                  value={datasetIdQuery}
+                  onChange={(e) => {
+                    setDatasetIdQuery(e.target.value);
+                    debouncedHandleDatasetIdSearch(e);
+                  }}
                 />
               </div>
             </Form.Group>
           </Col>
-          <Col md={12} lg={6}>
+          <Col md={12} lg={4}>
             <SortRefreshComponent
               handleRefresh={handleRefresh}
               handleSortChange={handleSortChange}
@@ -313,29 +353,15 @@ const ReleasedDatasets = () => {
             <Row className="mb-3">
               <Col md={4} className={style.datasetFilterBlock}>
                 <Form.Group>
-                  <div className={style.labelWithClear}>
-                    <Form.Label htmlFor="dataset-search">Dataset</Form.Label>
-                    <button
-                      type="button"
-                      className={style.clearButton}
-                      onClick={() => {
-                        setQuery("");
-                        debouncedHandleSearch({ target: { value: "" } });
-                      }}
-                      aria-label="Clear dataset search"
-                    >
-                      Clear
-                    </button>
-                  </div>
-                  <Form.Control
-                    id='dataset-search'
-                    value={query}
-                    aria-label="Search Dataset"
-                    placeholder="Search Dataset"
-                    onChange={(e) => {
-                      setQuery(e.target.value);
-                      debouncedHandleSearch(e);
-                    }}
+                  <Form.Label htmlFor="type-filter">Type</Form.Label>
+                  <Select
+                    inputId='type-filter'
+                    isSearchable={false}
+                    defaultValue={{ label: "All", value: "" }}
+                    onChange={handleSelectedDataType}
+                    options={options}
+                    components={{ IndicatorSeparator: () => null }}
+                    aria-label='Filter by Type'
                   />
                 </Form.Group>
               </Col>
@@ -378,34 +404,6 @@ const ReleasedDatasets = () => {
               </Col>
             </Row>
             <Row className="">
-              <Col md={4} className={style.datasetFilterBlock}>
-                <Form.Group>
-                  <div className={style.labelWithClear}>
-                    <Form.Label htmlFor="dataset-id-search">Dataset ID</Form.Label>
-                    <button
-                      type="button"
-                      className={style.clearButton}
-                      onClick={() => {
-                        setDatasetIdQuery("");
-                        handleDatasetIdSearch({ target: { value: "" } });
-                      }}
-                      aria-label="Clear dataset ID search"
-                    >
-                      Clear
-                    </button>
-                  </div>
-                  <Form.Control
-                    id='dataset-id-search'
-                    aria-label="Search Dataset ID"
-                    placeholder="Search Dataset ID"
-                    value={datasetIdQuery}
-                    onChange={(e) => {
-                      setDatasetIdQuery(e.target.value);
-                      debouncedHandleDatasetIdSearch(e);
-                    }}
-                  />
-                </Form.Group>
-              </Col>
               <Col md={4} className={style.datasetFilterBlock}>
                 <div className={style.labelWithClear}>
                   <Form.Label htmlFor="valid-from">Valid From</Form.Label>


### PR DESCRIPTION
## DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3560

### Changes Implemented:

* The primary filter area in both `MyDatasets` and `ReleasedDatasets` was expanded to occupy more horizontal space, and filter blocks now use flexbox for better responsiveness. The Dataset ID filter was added to the primary filter area, making it more accessible. 

* The primary and secondary filter containers in `Datasets.module.css` were updated to use flexbox layouts, improving alignment and responsiveness across different screen sizes. 

**Filter Logic and Component Refactoring:**

* The filter logic for admins and non-admins was refactored: admin users now see a "Project Group" and "Service" filter in the secondary filter area, while non-admins see a "Dataset ID" filter. The Service filter uses a new `ServiceAutocomplete` component. 

* The "Type" and "Status" filters were moved to the secondary filter area, making primary filters more focused and consistent between the two pages.

### Screenshots:
<img width="1470" height="956" alt="Screenshot 2026-04-30 at 2 51 13 PM" src="https://github.com/user-attachments/assets/700ac6b4-c466-4396-ab3e-eead56cfdada" />
<img width="1470" height="956" alt="Screenshot 2026-04-30 at 2 46 34 PM" src="https://github.com/user-attachments/assets/111f7896-7b66-437f-afee-6ac6d556f9de" />
<img width="1470" height="956" alt="Screenshot 2026-04-30 at 2 46 39 PM" src="https://github.com/user-attachments/assets/c88b7196-71a1-45a8-8eef-306d6621035e" />


