### PR TITLE
Stage to Prod

### DIFF
--- a/tdei-ui/src/assets/api_spec.json
+++ b/tdei-ui/src/assets/api_spec.json
@@ -1395,6 +1395,73 @@
                 ]
             }
         },
+        "/api/v1/osw/sanitize": {
+            "post": {
+                "tags": [
+                    "OSW"
+                ],
+                "summary": "Sanitizes the osw dataset.",
+                "description": "Allows a user to sanitize an OSW dataset by correcting invalid or unsupported values. The response includes a `job_id` for tracking the request. To check the request status, refer to the location header in the response, which provides the URL for the status API endpoint.",
+                "operationId": "sanitizeOswFile",
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "required": [
+                                    "dataset"
+                                ],
+                                "type": "object",
+                                "properties": {
+                                    "dataset": {
+                                        "type": "string",
+                                        "format": "binary",
+                                        "description": "OSW file which is expected to be a zip file, internally has {nodes, edges, zones}.geojson. If the extensions are present, then the zip file will have {lines, polygons, points}.geojson files"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "The sanitize request has been accepted for processing. It returns a `job_id`, a unique identifier for the sanitize request, which can be used to track the status of the request. The endpoint to check the status is provided in the location header of the response.",
+                        "content": {
+                            "application/text": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "description": "Location api to find the status of request processing"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Dataset input file not found."
+                    },
+                    "401": {
+                        "description": "Unauthenticated request. Check your access token."
+                    },
+                    "403": {
+                        "description": "User unauthorized to sanitize the dataset."
+                    },
+                    "500": {
+                        "description": "An Internal server error occured"
+                    }
+                },
+                "security": [
+                    {
+                        "AuthorizationToken": []
+                    }
+                ]
+            }
+        },
         "/api/v1/osw/convert": {
             "post": {
                 "tags": [

--- a/tdei-ui/src/components/JobListItem/JobListItem.js
+++ b/tdei-ui/src/components/JobListItem/JobListItem.js
@@ -29,6 +29,7 @@ const JobListItem = ({ jobItem }) => {
 
   const JOB_TYPE_LABELS = {
     "Dataset-BBox": "Filter Dataset By BBox",
+    "Dataset-Sanitization": "Dataset Sanitization",
   };
 
   const handleToast = () => {
@@ -234,13 +235,18 @@ const JobListItem = ({ jobItem }) => {
         {(jobItem.job_type === "Dataset-Reformat" ||
           jobItem.job_type === "Dataset-BBox" ||
           jobItem.job_type === "Dataset-Road-Tag" ||
+          jobItem.job_type === "Dataset-Sanitization" ||
           jobItem.job_type === "Dataset-Spatial-Join" ||
           jobItem.job_type === "Dataset-Union" ||
           jobItem.job_type === "Quality-Metric" ||
           jobItem.job_type === "Confidence-Calculate"
         ) &&
           jobItem.status.toLowerCase() === "completed" &&
-          (jobItem.download_url || jobItem.job_type === "Quality-Metric" || (jobItem.job_type === "Confidence-Calculate" && jobItem.response_props)) && (
+          (jobItem.download_url ||
+            jobItem.job_type === "Dataset-Sanitization" ||
+            jobItem.job_type === "Sanitization" ||
+            jobItem.job_type === "Quality-Metric" ||
+            (jobItem.job_type === "Confidence-Calculate" && jobItem.response_props)) && (
             <button
               type="button"
               id={jobItem.job_id}

--- a/tdei-ui/src/routes/Jobs/CreateJob.js
+++ b/tdei-ui/src/routes/Jobs/CreateJob.js
@@ -24,6 +24,7 @@ import SpatialJoinForm from "./SpatialJoinForm";
 // Options for the Job Type dropdown
 const jobTypeOptions = [
     { value: 'osw-validate', label: 'OSW - Validate' },
+    { value: 'osw-sanitize', label: 'OSW - Sanitize' },
     { value: 'flex-validate', label: 'Flex - Validate' },
     { value: 'pathways-validate', label: 'Pathways - Validate' },
     { value: 'osw-convert', label: 'OSW - Convert' },
@@ -48,6 +49,9 @@ const formConfig = {
     "osw-convert": [
         { label: "Source Format", type: "select", options: formatOptions, stateSetter: "setSourceFormat" },
         { label: "Target Format", type: "select", options: formatOptions, stateSetter: "setTargetFormat" },
+        { label: "Attach data file", type: "dropzone" }
+    ],
+    "osw-sanitize": [
         { label: "Attach data file", type: "dropzone" }
     ],
     "flex-validate": [
@@ -300,6 +304,7 @@ const CreateJobService = () => {
     const getPathFromJobType = (jobType) => {
         const jobTypePathMap = {
             "osw-validate": "/api/v1/osw/validate",
+            "osw-sanitize": "/api/v1/osw/sanitize",
             "flex-validate": "/api/v1/gtfs-flex/validate",
             "pathways-validate": "/api/v1/gtfs-pathways/validate",
             "osw-convert": "/api/v1/osw/convert",
@@ -406,7 +411,7 @@ const CreateJobService = () => {
             setShowValidateToast(true);
             return;
         }
-        if (!selectedFile && ["osw-validate", "flex-validate", "pathways-validate", "osw-convert"].includes(jobType.value)) {
+        if (!selectedFile && ["osw-validate", "osw-sanitize", "flex-validate", "pathways-validate", "osw-convert"].includes(jobType.value)) {
             setValidateErrorMessage("File is required");
             setShowValidateToast(true);
             return;
@@ -474,6 +479,9 @@ const CreateJobService = () => {
         switch (jobType?.value) {
             case "osw-validate":
                 urlPath = "osw/validate";
+                break;
+            case "osw-sanitize":
+                urlPath = "osw/sanitize";
                 break;
             case "flex-validate":
                 urlPath = "gtfs-flex/validate";

--- a/tdei-ui/src/routes/Jobs/Jobs.js
+++ b/tdei-ui/src/routes/Jobs/Jobs.js
@@ -47,6 +47,7 @@ const Jobs = () => {
         { value: 'Dataset-Publish', label: 'Dataset Publish' },
         { value: 'Dataset-Reformat', label: 'Dataset Reformat' },
         { value: 'Dataset-Road-Tag', label: 'Dataset Road Tag' },
+        { value: 'Dataset-Sanitize', label: 'Dataset Sanitize' },
         { value: 'Dataset-Spatial-Join', label: 'Dataset Spatial Join' },
         { value: 'Dataset-Union', label: 'Dataset Union' },
         { value: 'Dataset-Upload', label: 'Dataset Upload' },

--- a/tdei-ui/src/routes/Jobs/Jobs.js
+++ b/tdei-ui/src/routes/Jobs/Jobs.js
@@ -47,7 +47,7 @@ const Jobs = () => {
         { value: 'Dataset-Publish', label: 'Dataset Publish' },
         { value: 'Dataset-Reformat', label: 'Dataset Reformat' },
         { value: 'Dataset-Road-Tag', label: 'Dataset Road Tag' },
-        { value: 'Dataset-Sanitize', label: 'Dataset Sanitize' },
+        { value: 'Dataset-Sanitization', label: 'Dataset Sanitization' },
         { value: 'Dataset-Spatial-Join', label: 'Dataset Spatial Join' },
         { value: 'Dataset-Union', label: 'Dataset Union' },
         { value: 'Dataset-Upload', label: 'Dataset Upload' },


### PR DESCRIPTION
## DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3632

### Changes Implemented:

**API Integration and Job Submission:**
* Added a new API endpoint `/api/v1/osw/sanitize` to the OpenAPI spec, allowing users to submit OSW datasets for sanitization and receive a `job_id` for status tracking.
* Updated job creation logic to support the "osw-sanitize" job type, including mapping it to the correct API path, updating form validation to require a file, and configuring the form to display only the file upload field for this job type. 

**UI Enhancements for Job Types and Listings:**
* Added "OSW - Sanitize" and "Dataset Sanitize" as selectable job types in job creation and job filtering dropdowns
* Updated job list item display to recognize and label "Dataset-Sanitization" jobs, and to provide download buttons for completed sanitization jobs. 

### Impacted Areas for Testing  

- Create Job flow: verify OSW - Sanitize appears in the Create Job dropdown, accepts the expected .zip dataset upload, and successfully submits to create a sanitize job.
- Jobs listing and filtering: verify completed sanitize jobs appear with the expected job type label (Dataset Sanitization or equivalent), can be found via the Job Type filter, and display the Download Result action.
- Result download behavior: verify clicking Download Result for a completed sanitize job calls the existing job download endpoint and downloads the sanitized output file successfully.

### Screenshots:
<img width="1470" height="956" alt="Screenshot 2026-05-07 at 12 33 13 PM" src="https://github.com/user-attachments/assets/5ea5ac4d-f3d8-4bfa-b191-ddb71bae259a" />
<img width="1470" height="956" alt="Screenshot 2026-05-07 at 12 33 26 PM" src="https://github.com/user-attachments/assets/3e9d756d-c59f-4ac5-881a-57b1838d7d4f" />
