### PR TITLE
Issue 3704 : Add logged-in referral join

### DIFF
--- a/tdei-ui/src/components/Referral/LoggedInReferralJoinModal.js
+++ b/tdei-ui/src/components/Referral/LoggedInReferralJoinModal.js
@@ -1,0 +1,164 @@
+import React from "react";
+import { Alert, Button, Modal, Spinner } from "react-bootstrap";
+import { useDispatch } from "react-redux";
+import { useLocation, useNavigate } from "react-router-dom";
+import useApplyReferralCode from "../../hooks/referrals/useApplyReferralCode";
+import useReferralCodeLookup from "../../hooks/referrals/useReferralCodeLookup";
+import { show } from "../../store/notification.slice";
+
+function getJoinFailureMessage(err) {
+  return (
+    err?.response?.data?.message ||
+    err?.message ||
+    err?.response?.data ||
+    "Failed to join with referral code."
+  );
+}
+
+function toCurrentRoute(location) {
+  return {
+    pathname: location.pathname,
+    search: location.search,
+  };
+}
+
+export default function LoggedInReferralJoinModal() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const [activeReferralCode, setActiveReferralCode] = React.useState("");
+
+  React.useEffect(() => {
+    const referralCode = (location.state?.loggedInReferralCode || "").trim();
+    if (!referralCode) return;
+
+    setActiveReferralCode((currentCode) => currentCode || referralCode);
+
+    const nextState = { ...(location.state || {}) };
+    delete nextState.loggedInReferralCode;
+
+    navigate(
+      {
+        pathname: location.pathname,
+        search: location.search,
+      },
+      {
+        replace: true,
+        state: Object.keys(nextState).length ? nextState : null,
+      }
+    );
+  }, [location.pathname, location.search, location.state, navigate]);
+
+  const fallbackTo = toCurrentRoute(location);
+  const referralCode = activeReferralCode;
+  const {
+    details,
+    error,
+    isLoading,
+    isInvalid,
+    message,
+  } = useReferralCodeLookup(referralCode);
+
+  const handleClose = React.useCallback(() => {
+    sessionStorage.removeItem("referralCode");
+    setActiveReferralCode("");
+    navigate(fallbackTo, { replace: true });
+  }, [fallbackTo, navigate]);
+
+  const { mutate: applyReferralCode, isLoading: isApplying } = useApplyReferralCode({
+    onSuccess: () => {
+      sessionStorage.removeItem("referralCode");
+      setActiveReferralCode("");
+      dispatch(show({
+        type: "success",
+        message: "Referral code applied successfully. You can now switch to the joined project group.",
+      }));
+      navigate("/projectGroupSwitch", { replace: true, state: { from: fallbackTo } });
+    },
+    onError: (err) => {
+      sessionStorage.removeItem("referralCode");
+      setActiveReferralCode("");
+      dispatch(show({ type: "danger", message: getJoinFailureMessage(err) }));
+      navigate(fallbackTo, { replace: true });
+    },
+  });
+
+  const handleConfirmJoin = React.useCallback(() => {
+    applyReferralCode(referralCode);
+  }, [applyReferralCode, referralCode]);
+
+  if (!referralCode) return null;
+
+  return (
+    <Modal
+      show
+      centered
+      onHide={() => {
+        if (!isApplying) handleClose();
+      }}
+    >
+      <Modal.Header closeButton={!isApplying}>
+        <Modal.Title>{isInvalid ? "Referral Unavailable" : "Join With Referral Code"}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {isInvalid ? (
+          <Alert className="mb-0" variant="warning">
+            {message}
+          </Alert>
+        ) : (
+          <p className="mb-3">
+          Review the referral details and confirm if you want to continue.
+          </p>
+        )}
+
+        <div className={isInvalid ? "mt-3 mb-0" : "mb-2"}>
+          <strong>Referral Code:</strong> {String(referralCode).toUpperCase()}
+        </div>
+
+        {details?.name ? (
+          <div className="mb-2">
+            <strong>Referral Name:</strong> {details.name}
+          </div>
+        ) : null}
+
+        {details?.type ? (
+          <div className="mb-0">
+            <strong>Referral Type:</strong> {details.type === 1 ? "Campaign" : "Invite"}
+          </div>
+        ) : null}
+
+        {isLoading && !isInvalid ? (
+          <div className="d-flex align-items-center gap-2 mt-3 text-muted">
+            <Spinner animation="border" size="sm" role="status" />
+            <span>Loading referral details...</span>
+          </div>
+        ) : null}
+
+        {error && !isInvalid ? (
+          <Alert className="mt-3 mb-0" variant="warning">
+            {message}
+          </Alert>
+        ) : null}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button
+          variant="outline-secondary"
+          className="tdei-secondary-button"
+          onClick={handleClose}
+          disabled={isApplying}
+        >
+          {isInvalid ? "Close" : "Cancel"}
+        </Button>
+        {!isInvalid ? (
+          <Button
+            className="tdei-primary-button"
+            onClick={handleConfirmJoin}
+            disabled={isApplying || isLoading || !!error}
+          >
+            {isApplying ? <Spinner size="sm" /> : "Continue"}
+          </Button>
+        ) : null}
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/tdei-ui/src/components/RequireGuest/RequireGuest.js
+++ b/tdei-ui/src/components/RequireGuest/RequireGuest.js
@@ -1,11 +1,21 @@
 import React from "react";
 import { matchPath, Navigate, Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
-import { buildShareDatasetPath } from "../../utils";
+import { SHOW_REFERRALS, buildShareDatasetPath } from "../../utils";
 
 const RequireGuest = () => {
   const { user } = useAuth();
   const location = useLocation();
+  const searchParams = React.useMemo(
+    () => new URLSearchParams(location.search),
+    [location.search]
+  );
+  const referralCode = (
+    searchParams.get("code")
+    || searchParams.get("referral_code")
+    || searchParams.get("refferal_code")
+    || ""
+  ).trim();
 
   // If already logged in, don't allow guest pages
   if (user) {
@@ -32,6 +42,18 @@ const RequireGuest = () => {
     }
 
     const to = (location.state && location.state.from) || "/";
+    if (SHOW_REFERRALS && referralCode) {
+      return (
+        <Navigate
+          to={to}
+          replace
+          state={{
+            ...(typeof location.state === "object" && location.state !== null ? location.state : {}),
+            loggedInReferralCode: referralCode,
+          }}
+        />
+      );
+    }
     return <Navigate to={to} replace />;
   }
   return <Outlet />;

--- a/tdei-ui/src/hooks/referrals/useReferralCodeLookup.js
+++ b/tdei-ui/src/hooks/referrals/useReferralCodeLookup.js
@@ -1,0 +1,60 @@
+import React from "react";
+import { useQuery } from "react-query";
+import { getReferralCodeDetails } from "../../services";
+
+function getReferralLookupMessage(details, error) {
+  if (error) {
+    return (
+      error?.response?.data?.message ||
+      error?.response?.data ||
+      error?.message ||
+      "Failed to load referral details."
+    );
+  }
+
+  if (typeof details === "string") {
+    return details.trim();
+  }
+
+  if (
+    details &&
+    typeof details === "object" &&
+    typeof details.message === "string"
+  ) {
+    return details.message.trim();
+  }
+
+  return "";
+}
+
+export default function useReferralCodeLookup(referralCode) {
+  const query = useQuery(
+    ["referral-code-details", referralCode],
+    () => getReferralCodeDetails(referralCode),
+    {
+      enabled: !!referralCode,
+      retry: false,
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  const message = React.useMemo(
+    () => getReferralLookupMessage(query.data, query.error),
+    [query.data, query.error]
+  );
+
+  const isInvalid = React.useMemo(() => {
+    if (!message) return false;
+    return /invalid|expired|not found/i.test(message);
+  }, [message]);
+
+  return {
+    ...query,
+    message,
+    isInvalid,
+    details:
+      query.data && typeof query.data === "object" && !Array.isArray(query.data)
+        ? query.data
+        : null,
+  };
+}

--- a/tdei-ui/src/routes/Root/Root.js
+++ b/tdei-ui/src/routes/Root/Root.js
@@ -8,6 +8,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { set } from "../../store";
 import { Outlet } from "react-router-dom";
 import ShareDatasetModalHost from "../../components/ShareDataset/ShareDatasetModalHost";
+import LoggedInReferralJoinModal from "../../components/Referral/LoggedInReferralJoinModal";
 
 const Root = () => {
   const { data: projectGroupData, isLoading: isProjectGroupLoading, isError } = useGetProjectGroupRoles();
@@ -66,6 +67,7 @@ const Root = () => {
           <main className={style.contentBlock} id="main-content" tabIndex={-1}>
             <Outlet roles={roles} />
             <ShareDatasetModalHost />
+            <LoggedInReferralJoinModal />
           </main>
         </div>
       )}


### PR DESCRIPTION
# DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3704

## Changes Implemented:
Previously, if an authenticated user opened a referral link, the app redirected away from the guest route and no referral membership action happened. With this update, logged-in referral links now redirect into the normal authenticated route and open a confirmation modal over the standard app background. The user can review the referral code details and explicitly confirm before the referral is applied.

- RequireGuest now only detects authenticated referral-link visits and forwards the referral code through navigation state.
- Root hosts the logged-in referral modal so it renders inside the authenticated app layout.
- LoggedInReferralJoinModal handles:
   - consuming the referral code from route state
   - looking up referral metadata
   - showing loading / invalid / confirm states
   - applying the referral code on confirmation
   - redirecting to Project Group Switch on success
 - Added useReferralCodeLookup to isolate referral lookup/query logic.

### Impacted Areas For Testing:
- Logged-in user opens a valid referral link
- Logged-in user opens an invalid/expired referral link
- Guest referral login/register flow still works unchanged

### Screenshots:
<img width="1469" height="828" alt="Screenshot 2026-06-08 at 4 34 39 PM" src="https://github.com/user-attachments/assets/d94b1da2-3c5e-4275-9568-1f8240bd8812" />




