### PR TITLE
Enable share-dataset flow by removing feature flag

### DIFF
--- a/tdei-ui/src/components/AuthProvider/AuthProvider.js
+++ b/tdei-ui/src/components/AuthProvider/AuthProvider.js
@@ -8,7 +8,7 @@ import ResponseToast from "../ToastMessage/ResponseToast";
 import { clear } from "../../store";
 import { useDispatch } from "react-redux";
 import { useQueryClient } from "react-query";
-import { isShareDatasetRoute, SHOW_SHARE_DATASET_FLOW } from "../../utils";
+import { isShareDatasetRoute } from "../../utils";
 
 const AuthProvider = ({ children }) => {
   const navigate = useNavigate();
@@ -37,9 +37,9 @@ const AuthProvider = ({ children }) => {
 
     return anonymousPaths.has(normalizedPath)
       || normalizedPath.startsWith("/app-link/")
-      || (SHOW_SHARE_DATASET_FLOW && normalizedPath.startsWith("/login/share-dataset/"))
-      || (SHOW_SHARE_DATASET_FLOW && normalizedPath.startsWith("/register/share-dataset/"))
-      || (SHOW_SHARE_DATASET_FLOW && isShareDatasetRoute(normalizedPath));
+      || normalizedPath.startsWith("/login/share-dataset/")
+      || normalizedPath.startsWith("/register/share-dataset/")
+      || isShareDatasetRoute(normalizedPath);
   }, []);
 
   const decodeToken = (accessToken) => {

--- a/tdei-ui/src/components/RequireAuth/RequireAuth.js
+++ b/tdei-ui/src/components/RequireAuth/RequireAuth.js
@@ -2,13 +2,13 @@ import React from "react";
 import { matchPath, Navigate, Outlet } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
 import { useLocation } from "react-router-dom";
-import { buildShareDatasetAuthPath, isShareDatasetRoute, SHOW_SHARE_DATASET_FLOW } from "../../utils";
+import { buildShareDatasetAuthPath, isShareDatasetRoute } from "../../utils";
 
 function RequireAuth() {
   const { user } = useAuth();
   const location = useLocation();
   if (!user) {
-    if (SHOW_SHARE_DATASET_FLOW && isShareDatasetRoute(location.pathname)) {
+    if (isShareDatasetRoute(location.pathname)) {
       const shareMatch = matchPath(
         "/share-dataset/:data_type/:tdei_dataset_id",
         location.pathname

--- a/tdei-ui/src/components/RequireGuest/RequireGuest.js
+++ b/tdei-ui/src/components/RequireGuest/RequireGuest.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { matchPath, Navigate, Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
-import { buildShareDatasetPath, SHOW_SHARE_DATASET_FLOW } from "../../utils";
+import { buildShareDatasetPath } from "../../utils";
 
 const RequireGuest = () => {
   const { user } = useAuth();
@@ -9,7 +9,7 @@ const RequireGuest = () => {
 
   // If already logged in, don't allow guest pages
   if (user) {
-    if (SHOW_SHARE_DATASET_FLOW) {
+  
       const loginShareMatch = matchPath(
         "/login/share-dataset/:data_type/:tdei_dataset_id",
         location.pathname
@@ -31,7 +31,6 @@ const RequireGuest = () => {
           />
         );
       }
-    }
 
     const to = (location.state && location.state.from) || "/";
     return <Navigate to={to} replace />;

--- a/tdei-ui/src/routes/Datasets/DatasetsActions.js
+++ b/tdei-ui/src/routes/Datasets/DatasetsActions.js
@@ -19,7 +19,6 @@ import useIsMember from "../../hooks/roles/useIsMember";
 import { useAuth } from "../../hooks/useAuth";
 import useIsDataTypeGenerator from "../../hooks/useIsDataTypeGenerator";
 import { useMediaQuery } from 'react-responsive';
-import { SHOW_SHARE_DATASET_FLOW } from "../../utils";
 
 const DatasetsActions = ({
   status,
@@ -108,7 +107,7 @@ const DatasetsActions = ({
       icon: downloadDatasetImg,
       condition: true,
     },
-    SHOW_SHARE_DATASET_FLOW && (isReleasedDataset || status === "Publish") && {
+    (isReleasedDataset || status === "Publish") && {
       key: "shareDataset",
       label: "Share Link",
       icon: copyIcon,

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -25,7 +25,7 @@ import ProjectAutocomplete from "../../components/ProjectAutocomplete/ProjectAut
 import ServiceAutocomplete from "../../components/ServiceAutocomplete/ServiceAutocomplete";
 import DownloadModal from "../../components/DownloadModal/DownloadModal";
 import useCreateQualityReportJob from "../../hooks/jobs/useCreateQualityReportJob";
-import { buildShareDatasetPath, SHOW_SHARE_DATASET_FLOW } from "../../utils";
+import { buildShareDatasetPath } from "../../utils";
 
 const MyDatasets = () => {
   const queryClient = useQueryClient();
@@ -260,14 +260,6 @@ const MyDatasets = () => {
   };
 
   const copyShareLink = async (dataset) => {
-    if (!SHOW_SHARE_DATASET_FLOW) {
-      setEventKey("shareDataset");
-      setOperationResult("error");
-      setCustomErrorMessage("Share links are disabled in this branch.");
-      handleToast();
-      return;
-    }
-
     const sharePath = buildShareDatasetPath(
       dataset?.data_type,
       dataset?.tdei_dataset_id

--- a/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
+++ b/tdei-ui/src/routes/Datasets/ReleasedDatasets.js
@@ -8,7 +8,7 @@ import { Button, Form, Spinner, Col, Row } from "react-bootstrap";
 import style from "./Datasets.module.css";
 import Select from 'react-select';
 import iconNoData from "./../../assets/img/icon-noData.svg";
-import { buildShareDatasetPath, SHOW_SHARE_DATASET_FLOW, toPascalCase, formatDate } from '../../utils';
+import { buildShareDatasetPath, toPascalCase, formatDate } from '../../utils';
 import SortRefreshComponent from './SortRefreshComponent';
 import useGetReleasedDatasets from '../../hooks/service/useGetReleaseDatasets';
 import useDownloadDataset from '../../hooks/datasets/useDownloadDataset';
@@ -159,14 +159,6 @@ const ReleasedDatasets = () => {
   const handleRefresh = () => refreshData();
 
   const copyShareLink = async (dataset) => {
-    if (!SHOW_SHARE_DATASET_FLOW) {
-      setEventKey("shareDataset");
-      setOperationResult("error");
-      setCustomErrorMessage("Share links are disabled in this branch.");
-      handleToast();
-      return;
-    }
-
     const sharePath = buildShareDatasetPath(dataset?.data_type, dataset?.tdei_dataset_id);
     const shareUrl = `${window.location.origin}${sharePath}`;
 

--- a/tdei-ui/src/routes/Root/Root.js
+++ b/tdei-ui/src/routes/Root/Root.js
@@ -8,7 +8,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { set } from "../../store";
 import { Outlet } from "react-router-dom";
 import ShareDatasetModalHost from "../../components/ShareDataset/ShareDatasetModalHost";
-import { SHOW_SHARE_DATASET_FLOW } from "../../utils";
 
 const Root = () => {
   const { data: projectGroupData, isLoading: isProjectGroupLoading, isError } = useGetProjectGroupRoles();
@@ -66,7 +65,7 @@ const Root = () => {
           <Navigation />
           <main className={style.contentBlock} id="main-content" tabIndex={-1}>
             <Outlet roles={roles} />
-            {SHOW_SHARE_DATASET_FLOW && <ShareDatasetModalHost />}
+            <ShareDatasetModalHost />
           </main>
         </div>
       )}

--- a/tdei-ui/src/routes/index.js
+++ b/tdei-ui/src/routes/index.js
@@ -30,7 +30,7 @@ import CreateUpdateReferralCode from "./Referral/CreateUpdateReferralCode";
 import RequireGuest from "../components/RequireGuest/RequireGuest";
 import InviteInstructions from "./Referral/InviteInstructions";
 import AppLinkFallback from "../AppLinkFallback";
-import { SHOW_REFERRALS, SHOW_SHARE_DATASET_FLOW } from "../utils";
+import { SHOW_REFERRALS } from "../utils/helper";
 
 const Router = () => {
   const { user } = useAuth();
@@ -40,13 +40,9 @@ const Router = () => {
       <>
         <Route element={<RequireGuest />}>
           <Route path="/login" element={<LoginPage />} />
-          {SHOW_SHARE_DATASET_FLOW && (
-            <Route path="/login/share-dataset/:data_type/:tdei_dataset_id" element={<LoginPage />} />
-          )}
+          <Route path="/login/share-dataset/:data_type/:tdei_dataset_id" element={<LoginPage />} />
           <Route path="/register" element={<Register />} />
-          {SHOW_SHARE_DATASET_FLOW && (
-            <Route path="/register/share-dataset/:data_type/:tdei_dataset_id" element={<Register />} />
-          )}
+          <Route path="/register/share-dataset/:data_type/:tdei_dataset_id" element={<Register />} />
           <Route path="/ForgotPassword" element={<ForgotPassword />} />
           <Route path="/passwordReset" element={<PasswordResetConfirm />} />
           <Route path="/emailVerify" element={<EmailVerification />} />
@@ -60,9 +56,7 @@ const Router = () => {
         <Route element={<RequireAuth />}>
           <Route path="/" element={<Root />}>
             <Route path="/" element={<Dashboard />} />
-            {SHOW_SHARE_DATASET_FLOW && (
-              <Route path="/share-dataset/:data_type/:tdei_dataset_id" element={<Dashboard />} />
-            )}
+            <Route path="/share-dataset/:data_type/:tdei_dataset_id" element={<Dashboard />} />
             {user?.isAdmin && (
               <Route path="/projectGroup" element={<ProjectGroup />} />
             )}


### PR DESCRIPTION
Remove usage of the SHOW_SHARE_DATASET_FLOW feature flag and related conditional gating so the share-dataset flow is always available. Updated imports and simplified logic across multiple components and routes (AuthProvider, RequireAuth, RequireGuest, DatasetsActions, MyDatasets, ReleasedDatasets, Root, and routes/index.js) by deleting flag checks, removing no-op error branches, and always rendering share routes and the ShareDataset modal. Also adjusted a utils import in routes/index.js to use the helper module for SHOW_REFERRALS.