### PR TITLE
Dev To Stage

### DIFF
--- a/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.js
+++ b/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.js
@@ -1,0 +1,238 @@
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { Form, Spinner, InputGroup } from "react-bootstrap";
+import useGetProjectGroupRoles from "../../hooks/roles/useProjectGroupRoles";
+import styles from "./ProjectGroupRolesPicker.module.css";
+import { debounce } from "lodash";
+
+const ProjectGroupRolesPicker = ({
+  searchText,
+  setSearchText,
+  onSelectProjectGroup,
+  defaultProjectGroupId,
+  defaultProjectGroupName,
+}) => {
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [selectedGroup, setSelectedGroup] = useState(null);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [announcement, setAnnouncement] = useState("");
+  const [initialized, setInitialized] = useState(false);
+
+  const autocompleteRef = useRef();
+  const listRef = useRef();
+
+  const { data, isLoading } = useGetProjectGroupRoles(debouncedQuery);
+
+  const projectGroups = useMemo(() => {
+    const seen = new Set();
+    return (data?.pages?.flatMap((page) => page.data) || []).filter((pg) => {
+      if (seen.has(pg.tdei_project_group_id)) return false;
+      seen.add(pg.tdei_project_group_id);
+      return true;
+    });
+  }, [data]);
+
+  useEffect(() => {
+    if (!initialized && defaultProjectGroupId && defaultProjectGroupName) {
+      setSelectedGroup({
+        tdei_project_group_id: defaultProjectGroupId,
+        project_group_name: defaultProjectGroupName,
+      });
+      setSearchText(defaultProjectGroupName);
+      setInitialized(true);
+    }
+  }, [defaultProjectGroupId, defaultProjectGroupName, initialized, setSearchText]);
+
+  useEffect(() => {
+    if (searchText === "") {
+      if (defaultProjectGroupId && defaultProjectGroupName) {
+        setSelectedGroup({
+          tdei_project_group_id: defaultProjectGroupId,
+          project_group_name: defaultProjectGroupName,
+        });
+        setSearchText(defaultProjectGroupName);
+      } else {
+        setSelectedGroup(null);
+      }
+      setShowDropdown(false);
+    }
+  }, [searchText, defaultProjectGroupId, defaultProjectGroupName, setSearchText]);
+
+  const debouncedSearch = useMemo(
+    () => debounce((value) => setDebouncedQuery(value), 150),
+    []
+  );
+
+  const handleInputChange = (e) => {
+    const value = e.target.value;
+    setSearchText(value);
+    if (value.trim() === "") {
+      setSelectedGroup(null);
+      onSelectProjectGroup(null);
+      setShowDropdown(false);
+      return;
+    }
+    debouncedSearch(value);
+    setShowDropdown(true);
+    setHighlightedIndex(-1);
+  };
+
+  const handleSelect = (group) => {
+    setSelectedGroup(group);
+    setSearchText(group.project_group_name);
+    setShowDropdown(false);
+    setHighlightedIndex(-1);
+    onSelectProjectGroup(group.tdei_project_group_id);
+  };
+
+  const handleKeyDown = (e) => {
+    if (!showDropdown || projectGroups.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        prev < projectGroups.length - 1 ? prev + 1 : prev
+      );
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (highlightedIndex >= 0 && projectGroups[highlightedIndex]) {
+        handleSelect(projectGroups[highlightedIndex]);
+      }
+    } else if (e.key === "Escape" || e.key === "Tab") {
+      if (e.key === "Tab") e.preventDefault();
+      setShowDropdown(false);
+      setHighlightedIndex(-1);
+    }
+  };
+
+  useEffect(() => {
+    if (highlightedIndex >= 0 && listRef.current) {
+      const item = listRef.current.children[highlightedIndex];
+      if (item) item.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlightedIndex]);
+
+  useEffect(() => {
+    if (showDropdown && !isLoading && projectGroups.length > 0) {
+      setAnnouncement(
+        `${projectGroups.length} result${projectGroups.length === 1 ? "" : "s"} available. Use arrow keys to navigate.`
+      );
+    } else if (showDropdown && !isLoading && projectGroups.length === 0) {
+      setAnnouncement("No project groups found.");
+    } else {
+      setAnnouncement("");
+    }
+  }, [showDropdown, isLoading, projectGroups.length]);
+
+  const handleClickOutside = useCallback((e) => {
+    if (autocompleteRef.current && !autocompleteRef.current.contains(e.target)) {
+      setShowDropdown(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      debouncedSearch.cancel();
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [handleClickOutside, debouncedSearch]);
+
+  const listboxId = "project-group-roles-listbox";
+  const activeDescendant =
+    highlightedIndex >= 0 && projectGroups[highlightedIndex]
+      ? `pg-option-${projectGroups[highlightedIndex].tdei_project_group_id}`
+      : undefined;
+  const isExpanded = showDropdown && projectGroups.length > 0;
+
+  return (
+    <div className={styles.autocompleteContainer} ref={autocompleteRef}>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: "absolute",
+          width: "1px",
+          height: "1px",
+          overflow: "hidden",
+          clip: "rect(0,0,0,0)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {announcement}
+      </div>
+
+      <InputGroup>
+        <Form.Control
+          type="text"
+          placeholder="Search Project Group"
+          onChange={handleInputChange}
+          value={selectedGroup ? selectedGroup.project_group_name : searchText}
+          onFocus={() => {
+            setDebouncedQuery("");
+            setShowDropdown(true);
+          }}
+          onKeyDown={handleKeyDown}
+          autoComplete="off"
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded={isExpanded}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={activeDescendant}
+          aria-label="Search Project Group"
+        />
+        {isLoading && (
+          <InputGroup.Text>
+            <Spinner animation="border" size="sm" aria-label="Loading results" />
+          </InputGroup.Text>
+        )}
+      </InputGroup>
+
+      {showDropdown && projectGroups.length > 0 && (
+        <div
+          role="listbox"
+          id={listboxId}
+          aria-label="Project Groups"
+          className={styles.dropdownList}
+          ref={listRef}
+          tabIndex="-1"
+        >
+          {projectGroups.map((group, index) => {
+            const optionId = `pg-option-${group.tdei_project_group_id}`;
+            const isSelected =
+              selectedGroup?.tdei_project_group_id === group.tdei_project_group_id;
+            return (
+              <div
+                key={group.tdei_project_group_id}
+                id={optionId}
+                role="option"
+                aria-selected={isSelected}
+                className={`${styles.dropdownItem} ${
+                  highlightedIndex === index
+                    ? styles.highlighted
+                    : isSelected
+                    ? styles.active
+                    : ""
+                }`}
+                onClick={() => handleSelect(group)}
+              >
+                {group.project_group_name}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {showDropdown && projectGroups.length === 0 && !isLoading && (
+        <div className={styles.noResults} role="status">
+          No project groups found.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default React.memo(ProjectGroupRolesPicker);

--- a/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.module.css
+++ b/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.module.css
@@ -1,0 +1,43 @@
+.autocompleteContainer {
+  position: relative;
+  width: 100%;
+}
+
+.dropdownList {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #ced4da;
+  border-top: none;
+  background-color: #fff;
+  z-index: 1000;
+  outline: none;
+}
+
+.dropdownItem {
+  padding: 8px 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.dropdownItem:hover {
+  background-color: #f8f9fa;
+}
+
+.active {
+  background-color: #f8f9fa;
+}
+
+.highlighted,
+.highlighted:hover {
+  background-color: #deebff;
+  outline: none;
+}
+
+.noResults {
+  padding: 8px 12px;
+  color: #6c757d;
+}

--- a/tdei-ui/src/hooks/service/useGetDatasets.js
+++ b/tdei-ui/src/hooks/service/useGetDatasets.js
@@ -1,18 +1,15 @@
 import { useInfiniteQuery } from "react-query";
 import { useState } from "react";
-import { useSelector } from "react-redux";
-import { getSelectedProjectGroup } from "../../selectors";
 import { GET_DATASETS } from "../../utils";
 import { getDatasets } from "../../services";
 
-function useGetDatasets(isAdmin, searchText = "", searchDatasetId = "",status = "All", dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId,sortField, sortOrder) {
-  const { tdei_project_group_id } = useSelector(getSelectedProjectGroup);
+function useGetDatasets(isAdmin, searchText = "", searchDatasetId = "",status = "All", dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId, includeMyGroups, sortField, sortOrder) {
   const [refreshKey, setRefreshKey] = useState(0); // for refreshing data
   
   const { data, isError, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery(
-    [GET_DATASETS, searchText,searchDatasetId, status, dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId, tdei_project_group_id, sortField, sortOrder,refreshKey],
+    [GET_DATASETS, isAdmin, searchText,searchDatasetId, status, dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId, includeMyGroups, sortField, sortOrder,refreshKey],
     ({ pageParam }) =>
-      getDatasets(searchText,searchDatasetId, pageParam, isAdmin, status, dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId, tdei_project_group_id,sortField,sortOrder),
+      getDatasets(searchText,searchDatasetId, pageParam, isAdmin, status, dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId, includeMyGroups, sortField,sortOrder),
     {
       getNextPageParam: (lastPage) => {
         return lastPage.data.length > 0 && lastPage.data.length === 10

--- a/tdei-ui/src/routes/Datasets/Datasets.module.css
+++ b/tdei-ui/src/routes/Datasets/Datasets.module.css
@@ -321,7 +321,8 @@
   width: 40px;
   height: 40px;
   margin-top: 30px !important;
-  margin-right: 15px !important;
+  margin-right: 0 !important;
+  flex: 0 0 40px;
 }
 .sortByField {
   width: 300px;
@@ -341,7 +342,8 @@
   border: 1px solid #CED4DA !important;
   border-radius: 8px !important;
   opacity: 1 !important; 
-  width: 120px;
+  width: 104px;
+  min-width: 104px !important;
   height: 40px;
   margin-top: 30px !important;
   color: black !important;
@@ -388,15 +390,36 @@
     flex: 1 1 0;
     min-width: 0;
   }
+  .primaryFilterBlockScope {
+    flex: 1 1 0;
+    min-width: 0;
+  }
   .primaryFilterBlock_Released {
     flex: 1 1 0;
     min-width: 0;
   }
 }
+.datasetScopeSelect {
+  width: 100%;
+}
+.datasetScopeSelect :global(.datasetScopeSelect__control) {
+  border: 1px solid #ced4da;
+  border-radius: 0.375rem;
+  min-height: calc(1.5em + 0.75rem + 2px);
+  box-shadow: none;
+}
+.datasetScopeSelect :global(.datasetScopeSelect__control:hover) {
+  border-color: #ced4da;
+}
+.datasetScopeSelect :global(.datasetScopeSelect__control--is-focused) {
+  border-color: #86b7fe;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
 .secondaryFilterContainer {
   display: flex;
   justify-content: flex-end;
-  gap: 15px;
+  flex-wrap: nowrap;
+  gap: 10px;
 }
 .typeNameTransform {
   text-transform: uppercase;
@@ -471,6 +494,11 @@
     align-items: stretch;
     .primaryFilterBlock {
       width: 100%;
+      flex: none;
+    }
+    .primaryFilterBlockScope {
+      width: 100%;
+      min-width: 0;
       flex: none;
     }
     .primaryFilterBlock_Released {

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -26,6 +26,9 @@ import ServiceAutocomplete from "../../components/ServiceAutocomplete/ServiceAut
 import DownloadModal from "../../components/DownloadModal/DownloadModal";
 import useCreateQualityReportJob from "../../hooks/jobs/useCreateQualityReportJob";
 import { buildShareDatasetPath } from "../../utils";
+import { useSelector } from "react-redux";
+import { getSelectedProjectGroup } from "../../selectors";
+import ProjectGroupRolesPicker from "../../components/ProjectGroupRolesPicker/ProjectGroupRolesPicker";
 
 const MyDatasets = () => {
   const queryClient = useQueryClient();
@@ -47,7 +50,11 @@ const MyDatasets = () => {
   const [eventKey, setEventKey] = useState("");
   const [operationResult, setOperationResult] = useState("");
   const isAdmin = user && user.isAdmin;
+  const selectedProjectGroup = useSelector(getSelectedProjectGroup);
   const [selectedProjectGroupId, setSelectedProjectGroupId] = useState(null);
+  // Filter override for non-admin users: null means use the Redux selected project group
+  const [nonAdminProjectGroupId, setNonAdminProjectGroupId] = useState(null);
+  // The project group ID to pass to useGetDatasets for non-admins (null = use Redux default)
   const [sortField, setSortField] = useState("uploaded_timestamp");
   const [sortOrder, setSortOrder] = useState("DESC");
   const [showDownloadModal, setShowDownloadModal] = useState(false);
@@ -70,12 +77,13 @@ const MyDatasets = () => {
     validFrom,
     validTo,
     tdeiServiceId,
-    selectedProjectGroupId,
+    isAdmin ? selectedProjectGroupId : nonAdminProjectGroupId,
     sortField,
     sortOrder
   );
   const [projectSearchText, setProjectSearchText] = useState("");
   const [serviceSearchText, setServiceSearchText] = useState("");
+  const [projectGroupSearchText, setProjectGroupSearchText] = useState("");
   const navigate = useNavigate();
   const [customErrorMessage, setCustomErrorMessage] = useState("");
   const [showFilters, setShowFilters] = useState(false);
@@ -93,6 +101,18 @@ const MyDatasets = () => {
     setServiceSearchText("");
     refreshData();
   };
+  const handleClearFilterProjectGroup = () => {
+    setNonAdminProjectGroupId(null);
+    setProjectGroupSearchText("");
+    refreshData();
+  };
+  const handleProjectGroupSelect = useCallback(
+    (projectGroupId) => {
+      setNonAdminProjectGroupId(projectGroupId || null);
+      refreshData();
+    },
+    [refreshData]
+  );
 
   useEffect(() => {
     if (data && data.pages && data.pages.length > 0) {
@@ -567,6 +587,32 @@ const MyDatasets = () => {
                 <Col md={4} className={style.datasetFilterBlock}>
                   <Form.Group>
                     <div className={style.labelWithClear}>
+                      <Form.Label>Project Group</Form.Label>
+                      <button
+                        type="button"
+                        className={style.clearButton}
+                        onClick={handleClearFilterProjectGroup}
+                        aria-label="Clear project group filter"
+                      >
+                        Clear
+                      </button>
+                    </div>
+                    <ProjectGroupRolesPicker
+                      searchText={projectGroupSearchText}
+                      setSearchText={setProjectGroupSearchText}
+                      onSelectProjectGroup={handleProjectGroupSelect}
+                      defaultProjectGroupId={selectedProjectGroup?.tdei_project_group_id}
+                      defaultProjectGroupName={selectedProjectGroup?.name}
+                    />
+                  </Form.Group>
+                </Col>
+              )}
+            </Row>
+            <Row className="">
+              {isAdmin && (
+                <Col md={4} className={style.datasetFilterBlock}>
+                  <Form.Group>
+                    <div className={style.labelWithClear}>
                       <Form.Label htmlFor="service-search">Service</Form.Label>
                       <button
                         type="button"
@@ -586,9 +632,7 @@ const MyDatasets = () => {
                   </Form.Group>
                 </Col>
               )}
-            </Row>
-            <Row className="">
-              {isAdmin && (
+              {!isAdmin && (
                 <Col md={4} className={style.datasetFilterBlock}>
                   <Form.Group>
                     <div className={style.labelWithClear}>

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -3,7 +3,7 @@ import DatasetTableHeader from "./DatasetTableHeader";
 import DatasetRow from "./DatasetRow";
 import { useQueryClient } from "react-query";
 import useGetDatasets from "../../hooks/service/useGetDatasets";
-import { GET_DATASETS, PUBLISH_DATASETS } from "../../utils";
+import { GET_DATASETS } from "../../utils";
 import { debounce } from "lodash";
 import style from "./Datasets.module.css";
 import Select from "react-select";
@@ -26,8 +26,6 @@ import ServiceAutocomplete from "../../components/ServiceAutocomplete/ServiceAut
 import DownloadModal from "../../components/DownloadModal/DownloadModal";
 import useCreateQualityReportJob from "../../hooks/jobs/useCreateQualityReportJob";
 import { buildShareDatasetPath } from "../../utils";
-import { useSelector } from "react-redux";
-import { getSelectedProjectGroup } from "../../selectors";
 import ProjectGroupRolesPicker from "../../components/ProjectGroupRolesPicker/ProjectGroupRolesPicker";
 
 const MyDatasets = () => {
@@ -50,11 +48,9 @@ const MyDatasets = () => {
   const [eventKey, setEventKey] = useState("");
   const [operationResult, setOperationResult] = useState("");
   const isAdmin = user && user.isAdmin;
-  const selectedProjectGroup = useSelector(getSelectedProjectGroup);
   const [selectedProjectGroupId, setSelectedProjectGroupId] = useState(null);
-  // Filter override for non-admin users: null means use the Redux selected project group
   const [nonAdminProjectGroupId, setNonAdminProjectGroupId] = useState(null);
-  // The project group ID to pass to useGetDatasets for non-admins (null = use Redux default)
+  const [includeMyGroups, setIncludeMyGroups] = useState(true);
   const [sortField, setSortField] = useState("uploaded_timestamp");
   const [sortOrder, setSortOrder] = useState("DESC");
   const [showDownloadModal, setShowDownloadModal] = useState(false);
@@ -78,6 +74,7 @@ const MyDatasets = () => {
     validTo,
     tdeiServiceId,
     isAdmin ? selectedProjectGroupId : nonAdminProjectGroupId,
+    isAdmin ? undefined : includeMyGroups,
     sortField,
     sortOrder
   );
@@ -136,6 +133,11 @@ const MyDatasets = () => {
     setStatus(list.value);
   };
 
+  const handleIncludeMyGroupsChange = (option) => {
+    setIncludeMyGroups(option?.value ?? true);
+    refreshData();
+  };
+
   const handleSearch = (e) => {
     setDebounceQuery(e.target.value);
   };
@@ -174,6 +176,11 @@ const MyDatasets = () => {
     { value: "All", label: "All" },
     { value: "Publish", label: "Released" },
     { value: "Pre-Release", label: "Pre-Release" },
+  ];
+
+  const includeMyGroupsOptions = [
+    { value: false, label: "All" },
+    { value: true, label: "My Project Groups" }
   ];
 
   const onSuccess = () => {
@@ -461,7 +468,7 @@ const MyDatasets = () => {
     <div>
       <Form noValidate>
         <Row className="my-3 gx-0">
-          <Col md={12} lg={8}>
+          <Col md={12} xxl={isAdmin ? 8 : 9}>
             <Form.Group className={style.primaryFilterContainer}>
               <div className={style.primaryFilterBlock}>
                 <div className={style.labelWithClear}>
@@ -515,9 +522,25 @@ const MyDatasets = () => {
                   }}
                 />
               </div>
+              {!isAdmin && (
+                <div className={style.primaryFilterBlockScope}>
+                  <Form.Label htmlFor="include-my-groups-filter">Dataset Scope</Form.Label>
+                  <Select
+                    className={style.datasetScopeSelect}
+                    classNamePrefix="datasetScopeSelect"
+                    inputId="include-my-groups-filter"
+                    isSearchable={false}
+                    value={includeMyGroupsOptions.find((option) => option.value === includeMyGroups)}
+                    onChange={handleIncludeMyGroupsChange}
+                    options={includeMyGroupsOptions}
+                    components={{ IndicatorSeparator: () => null }}
+                    aria-label="Filter by dataset scope"
+                  />
+                </div>
+              )}
             </Form.Group>
           </Col>
-          <Col md={12} lg={4}>
+          <Col md={12} xxl={isAdmin ? 4 : 3}>
             <SortRefreshComponent
               handleRefresh={handleRefresh}
               handleSortChange={handleSortChange}

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -601,8 +601,6 @@ const MyDatasets = () => {
                       searchText={projectGroupSearchText}
                       setSearchText={setProjectGroupSearchText}
                       onSelectProjectGroup={handleProjectGroupSelect}
-                      defaultProjectGroupId={selectedProjectGroup?.tdei_project_group_id}
-                      defaultProjectGroupName={selectedProjectGroup?.name}
                     />
                   </Form.Group>
                 </Col>

--- a/tdei-ui/src/services/apiServices.js
+++ b/tdei-ui/src/services/apiServices.js
@@ -601,7 +601,8 @@ export async function getDatasets(
   if (isAdmin && selectedProjectGroupId) {
     params.tdei_project_group_id = selectedProjectGroupId;
   } else if (!isAdmin) {
-    params.tdei_project_group_id = tdei_project_group_id;
+    // Use the filter override if set, otherwise fall back to the Redux selected project group
+    params.tdei_project_group_id = selectedProjectGroupId || tdei_project_group_id;
   }
 
   const res = await axios({

--- a/tdei-ui/src/services/apiServices.js
+++ b/tdei-ui/src/services/apiServices.js
@@ -600,9 +600,8 @@ export async function getDatasets(
   //Project ID if the user is admin
   if (isAdmin && selectedProjectGroupId) {
     params.tdei_project_group_id = selectedProjectGroupId;
-  } else if (!isAdmin) {
-    // Use the filter override if set, otherwise fall back to the Redux selected project group
-    params.tdei_project_group_id = selectedProjectGroupId || tdei_project_group_id;
+  } else if (!isAdmin && selectedProjectGroupId) {
+    params.tdei_project_group_id = selectedProjectGroupId;
   }
 
   const res = await axios({

--- a/tdei-ui/src/services/apiServices.js
+++ b/tdei-ui/src/services/apiServices.js
@@ -559,7 +559,7 @@ export async function getDatasets(
   validTo,
   tdei_service_id,
   selectedProjectGroupId,
-  tdei_project_group_id,
+  includeMyGroups,
   sortField = 'uploaded_timestamp',
   sortOrder = 'DESC'
 ) {
@@ -597,7 +597,11 @@ export async function getDatasets(
     params.tdei_service_id = tdei_service_id;
   }
 
-  //Project ID if the user is admin
+  if (!isAdmin && typeof includeMyGroups === "boolean") {
+    params.include_my_groups = includeMyGroups;
+  }
+
+  // Project ID if the user selected a local project group filter
   if (isAdmin && selectedProjectGroupId) {
     params.tdei_project_group_id = selectedProjectGroupId;
   } else if (!isAdmin && selectedProjectGroupId) {


### PR DESCRIPTION
# DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3682/

## Changes Implemented:

- Added a new `ProjectGroupRolesPicker` component for searching and selecting project groups, with keyboard accessibility and debounced search. Integrated this component into the datasets page for non-admin users.
- Introduced a "Dataset Scope" dropdown for non-admins to toggle between "All" datasets and those belonging to "My Project Groups." 
- Updated the `useGetDatasets` hook and `getDatasets` API service to support the new filters: `selectedProjectGroupId` and `includeMyGroups`, and removed reliance on Redux state for project group selection
- Adjusted the datasets API parameter logic to properly handle admin and non-admin filtering scenarios.
- Added and updated CSS modules for the new filter components, ensuring responsive layout and consistent styling for the autocomplete and dropdown elements. 

### Impacted Areas For Testing:
| User Type | Page / Tab | Dataset Scope | Status | API Parameters | Expected Results |
|------------|------------|--------------|--------|----------------|------------------|
| Non-Admin | My Project Datasets | My Project Groups (Default) | All | `include_my_groups=true` | Shows published and pre-release datasets belonging to the user's project groups only. |
| Non-Admin | My Project Datasets | My Project Groups | Released | `status=Publish`, `include_my_groups=true` | Shows only published datasets from the user's project groups. |
| Non-Admin | My Project Datasets | My Project Groups | Pre-Release | `status=Pre-Release`, `include_my_groups=true` | Shows only pre-release datasets from the user's project groups. |
| Non-Admin | My Project Datasets | All | All | `include_my_groups=false` | Shows all globally published datasets plus pre-release datasets from the user's project groups. |
| Non-Admin | My Project Datasets | All | Released | `status=Publish`, `include_my_groups=false` | Shows all published datasets globally. |
| Non-Admin | My Project Datasets | All | Pre-Release | `status=Pre-Release`, `include_my_groups=false` | Shows only pre-release datasets from the user's project groups. |
| Non-Admin | My Project Datasets | Any | Any | `tdei_project_group_id=<selected_id>` | Project Group filter narrows results to the selected project group. |
| Non-Admin | My Project Datasets | Any | Any | `tdei_project_group_id` removed | Clearing Project Group filter restores the broader result set based on Dataset Scope and Status. |
| Non-Admin | My Project Datasets | Any | Any | Additional filters applied | Dataset Name search, Dataset ID search, Service filter, and Date filters continue to work correctly alongside `include_my_groups`. |
| Non-Admin | All Released Datasets | N/A | Released | Existing behavior | Continues to show released/global datasets and is not affected by Dataset Scope. |
| Admin | Any Dataset View | Any | Released / Pre-Release / All | Existing behavior (`include_my_groups` not used) | Dataset behavior remains unchanged. |
| Accessibility | Dataset Scope Control | N/A | N/A | N/A | Dataset Scope control is fully keyboard accessible. |

#### Screenshots:
<img width="1470" height="875" alt="Screenshot 2026-06-09 at 6 33 14 PM" src="https://github.com/user-attachments/assets/19b80dd1-d812-4308-b99b-6b91eb3234f6" />
