### PR TITLE
Task-3682: Add dataset scope and disable project picker

### DIFF
--- a/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.js
+++ b/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.js
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
 import { Form, Spinner, InputGroup } from "react-bootstrap";
 import useGetProjectGroupRoles from "../../hooks/roles/useProjectGroupRoles";
 import styles from "./ProjectGroupRolesPicker.module.css";
@@ -10,13 +16,13 @@ const ProjectGroupRolesPicker = ({
   onSelectProjectGroup,
   defaultProjectGroupId,
   defaultProjectGroupName,
+  disabled = false,
 }) => {
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [selectedGroup, setSelectedGroup] = useState(null);
   const [showDropdown, setShowDropdown] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [announcement, setAnnouncement] = useState("");
-  const [initialized, setInitialized] = useState(false);
 
   const autocompleteRef = useRef();
   const listRef = useRef();
@@ -33,15 +39,25 @@ const ProjectGroupRolesPicker = ({
   }, [data]);
 
   useEffect(() => {
-    if (!initialized && defaultProjectGroupId && defaultProjectGroupName) {
+    if (
+      defaultProjectGroupId &&
+      defaultProjectGroupName &&
+      (disabled || searchText === "")
+    ) {
       setSelectedGroup({
         tdei_project_group_id: defaultProjectGroupId,
         project_group_name: defaultProjectGroupName,
       });
       setSearchText(defaultProjectGroupName);
-      setInitialized(true);
+      setShowDropdown(false);
     }
-  }, [defaultProjectGroupId, defaultProjectGroupName, initialized, setSearchText]);
+  }, [
+    defaultProjectGroupId,
+    defaultProjectGroupName,
+    disabled,
+    searchText,
+    setSearchText,
+  ]);
 
   useEffect(() => {
     if (searchText === "") {
@@ -56,7 +72,12 @@ const ProjectGroupRolesPicker = ({
       }
       setShowDropdown(false);
     }
-  }, [searchText, defaultProjectGroupId, defaultProjectGroupName, setSearchText]);
+  }, [
+    searchText,
+    defaultProjectGroupId,
+    defaultProjectGroupName,
+    setSearchText,
+  ]);
 
   const debouncedSearch = useMemo(
     () => debounce((value) => setDebouncedQuery(value), 150),
@@ -64,6 +85,8 @@ const ProjectGroupRolesPicker = ({
   );
 
   const handleInputChange = (e) => {
+    if (disabled) return;
+
     const value = e.target.value;
     setSearchText(value);
     if (value.trim() === "") {
@@ -117,7 +140,9 @@ const ProjectGroupRolesPicker = ({
   useEffect(() => {
     if (showDropdown && !isLoading && projectGroups.length > 0) {
       setAnnouncement(
-        `${projectGroups.length} result${projectGroups.length === 1 ? "" : "s"} available. Use arrow keys to navigate.`
+        `${projectGroups.length} result${
+          projectGroups.length === 1 ? "" : "s"
+        } available. Use arrow keys to navigate.`
       );
     } else if (showDropdown && !isLoading && projectGroups.length === 0) {
       setAnnouncement("No project groups found.");
@@ -127,7 +152,10 @@ const ProjectGroupRolesPicker = ({
   }, [showDropdown, isLoading, projectGroups.length]);
 
   const handleClickOutside = useCallback((e) => {
-    if (autocompleteRef.current && !autocompleteRef.current.contains(e.target)) {
+    if (
+      autocompleteRef.current &&
+      !autocompleteRef.current.contains(e.target)
+    ) {
       setShowDropdown(false);
     }
   }, []);
@@ -171,7 +199,9 @@ const ProjectGroupRolesPicker = ({
           placeholder="Search Project Group"
           onChange={handleInputChange}
           value={selectedGroup ? selectedGroup.project_group_name : searchText}
+          disabled={disabled}
           onFocus={() => {
+            if (disabled) return;
             setDebouncedQuery("");
             setShowDropdown(true);
           }}
@@ -187,7 +217,11 @@ const ProjectGroupRolesPicker = ({
         />
         {isLoading && (
           <InputGroup.Text>
-            <Spinner animation="border" size="sm" aria-label="Loading results" />
+            <Spinner
+              animation="border"
+              size="sm"
+              aria-label="Loading results"
+            />
           </InputGroup.Text>
         )}
       </InputGroup>
@@ -204,7 +238,8 @@ const ProjectGroupRolesPicker = ({
           {projectGroups.map((group, index) => {
             const optionId = `pg-option-${group.tdei_project_group_id}`;
             const isSelected =
-              selectedGroup?.tdei_project_group_id === group.tdei_project_group_id;
+              selectedGroup?.tdei_project_group_id ===
+              group.tdei_project_group_id;
             return (
               <div
                 key={group.tdei_project_group_id}

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -27,10 +27,17 @@ import DownloadModal from "../../components/DownloadModal/DownloadModal";
 import useCreateQualityReportJob from "../../hooks/jobs/useCreateQualityReportJob";
 import { buildShareDatasetPath } from "../../utils";
 import ProjectGroupRolesPicker from "../../components/ProjectGroupRolesPicker/ProjectGroupRolesPicker";
+import { useSelector } from "react-redux";
+import { getSelectedProjectGroup } from "../../selectors";
+
+const CURRENT_PROJECT_GROUP_SCOPE = "currentProjectGroup";
+const ALL_DATASETS_SCOPE = "all";
+const MY_PROJECT_GROUPS_SCOPE = "myProjectGroups";
 
 const MyDatasets = () => {
   const queryClient = useQueryClient();
   const { user } = useAuth();
+  const selectedProjectGroup = useSelector(getSelectedProjectGroup);
   const [isLoadingDownload, setIsLoadingDownload] = useState(false);
   const [query, setQuery] = useState("");
   const [debounceQuery, setDebounceQuery] = useState("");
@@ -50,12 +57,27 @@ const MyDatasets = () => {
   const isAdmin = user && user.isAdmin;
   const [selectedProjectGroupId, setSelectedProjectGroupId] = useState(null);
   const [nonAdminProjectGroupId, setNonAdminProjectGroupId] = useState(null);
-  const [includeMyGroups, setIncludeMyGroups] = useState(true);
+  const [datasetScope, setDatasetScope] = useState(CURRENT_PROJECT_GROUP_SCOPE);
   const [sortField, setSortField] = useState("uploaded_timestamp");
   const [sortOrder, setSortOrder] = useState("DESC");
   const [showDownloadModal, setShowDownloadModal] = useState(false);
   const [selectedFormat, setSelectedFormat] = useState(null);
   const [selectedFileVersion, setSelectedFileVersion] = useState(null);
+  const currentProjectGroupId =
+    selectedProjectGroup?.tdei_project_group_id ?? null;
+  const currentProjectGroupName = selectedProjectGroup?.name ?? "";
+  const isCurrentProjectGroupScope =
+    datasetScope === CURRENT_PROJECT_GROUP_SCOPE;
+  const effectiveNonAdminProjectGroupId = isCurrentProjectGroupScope
+    ? currentProjectGroupId
+    : nonAdminProjectGroupId;
+  const includeMyGroups = isAdmin
+    ? undefined
+    : datasetScope === MY_PROJECT_GROUPS_SCOPE
+    ? true
+    : datasetScope === ALL_DATASETS_SCOPE
+    ? false
+    : undefined;
   const {
     data = [],
     isError,
@@ -73,7 +95,7 @@ const MyDatasets = () => {
     validFrom,
     validTo,
     tdeiServiceId,
-    isAdmin ? selectedProjectGroupId : nonAdminProjectGroupId,
+    isAdmin ? selectedProjectGroupId : effectiveNonAdminProjectGroupId,
     isAdmin ? undefined : includeMyGroups,
     sortField,
     sortOrder
@@ -99,8 +121,13 @@ const MyDatasets = () => {
     refreshData();
   };
   const handleClearFilterProjectGroup = () => {
-    setNonAdminProjectGroupId(null);
-    setProjectGroupSearchText("");
+    if (isCurrentProjectGroupScope) {
+      setNonAdminProjectGroupId(currentProjectGroupId);
+      setProjectGroupSearchText(currentProjectGroupName);
+    } else {
+      setNonAdminProjectGroupId(null);
+      setProjectGroupSearchText("");
+    }
     refreshData();
   };
   const handleProjectGroupSelect = useCallback(
@@ -110,6 +137,18 @@ const MyDatasets = () => {
     },
     [refreshData]
   );
+
+  useEffect(() => {
+    if (!isAdmin && isCurrentProjectGroupScope) {
+      setNonAdminProjectGroupId(currentProjectGroupId);
+      setProjectGroupSearchText(currentProjectGroupName);
+    }
+  }, [
+    isAdmin,
+    isCurrentProjectGroupScope,
+    currentProjectGroupId,
+    currentProjectGroupName,
+  ]);
 
   useEffect(() => {
     if (data && data.pages && data.pages.length > 0) {
@@ -133,8 +172,18 @@ const MyDatasets = () => {
     setStatus(list.value);
   };
 
-  const handleIncludeMyGroupsChange = (option) => {
-    setIncludeMyGroups(option?.value ?? true);
+  const handleDatasetScopeChange = (option) => {
+    const nextScope = option?.value ?? CURRENT_PROJECT_GROUP_SCOPE;
+    setDatasetScope(nextScope);
+
+    if (nextScope === CURRENT_PROJECT_GROUP_SCOPE) {
+      setNonAdminProjectGroupId(currentProjectGroupId);
+      setProjectGroupSearchText(currentProjectGroupName);
+    } else {
+      setNonAdminProjectGroupId(null);
+      setProjectGroupSearchText("");
+    }
+
     refreshData();
   };
 
@@ -178,9 +227,13 @@ const MyDatasets = () => {
     { value: "Pre-Release", label: "Pre-Release" },
   ];
 
-  const includeMyGroupsOptions = [
-    { value: false, label: "All" },
-    { value: true, label: "My Project Groups" }
+  const datasetScopeOptions = [
+    { value: ALL_DATASETS_SCOPE, label: "All" },
+    {
+      value: CURRENT_PROJECT_GROUP_SCOPE,
+      label: "Current Project Group",
+    },
+    { value: MY_PROJECT_GROUPS_SCOPE, label: "My Project Groups" },
   ];
 
   const onSuccess = () => {
@@ -221,8 +274,10 @@ const MyDatasets = () => {
     useToggleDataviewer({ onSuccess, onError });
   const { mutate: createInclinationJob, isLoading: isCreatingJob } =
     useCreateInclinationJob({ onSuccess, onError });
-  const { mutate: createQualityReportJob, isLoading: isCreatingQualityReportJob } =
-    useCreateQualityReportJob({ onSuccess, onError });
+  const {
+    mutate: createQualityReportJob,
+    isLoading: isCreatingQualityReportJob,
+  } = useCreateQualityReportJob({ onSuccess, onError });
 
   const handlePublishDataset = (dataset) => {
     // Check if valid_from and valid_to dates are present
@@ -258,7 +313,7 @@ const MyDatasets = () => {
       // console.log("Quality report to be added for dataset: ", selectedDataset.tdei_dataset_id);
       createQualityReportJob(selectedDataset.tdei_dataset_id);
     }
-  }
+  };
 
   const handleCreateInclinationJob = () => {
     createInclinationJob(selectedDataset.tdei_dataset_id);
@@ -393,9 +448,11 @@ const MyDatasets = () => {
       modaltype: "error",
     },
     dataviewer: {
-      message: `Are you sure you want to ${selectedDataset?.data_viewer_allowed ? "disable" : "enable"
-        } the dataviewer status for dataset ${selectedDataset?.metadata?.dataset_detail?.name
-        }?`,
+      message: `Are you sure you want to ${
+        selectedDataset?.data_viewer_allowed ? "disable" : "enable"
+      } the dataviewer status for dataset ${
+        selectedDataset?.metadata?.dataset_detail?.name
+      }?`,
       content: "",
       handler: handleDataviewerChange,
       btnlabel: selectedDataset?.data_viewer_allowed ? "Disable" : "Enable",
@@ -408,7 +465,7 @@ const MyDatasets = () => {
       handler: handleCreateQualityReportJob,
       btnlabel: "Generate Quality Report",
       modaltype: "qualityReport",
-    }
+    },
   };
 
   const currentModalConfig = modalConfig[eventKey];
@@ -450,7 +507,8 @@ const MyDatasets = () => {
       case "qualityReport":
         return operationResult === "success"
           ? "Success! Quality report job has been initiated."
-          : customErrorMessage ?? "Error! Failed to initiate quality report job.";
+          : customErrorMessage ??
+              "Error! Failed to initiate quality report job.";
       default:
         return "";
     }
@@ -498,7 +556,9 @@ const MyDatasets = () => {
               </div>
               <div className={style.primaryFilterBlock}>
                 <div className={style.labelWithClear}>
-                  <Form.Label htmlFor="dataset-id-search-primary">Dataset ID</Form.Label>
+                  <Form.Label htmlFor="dataset-id-search-primary">
+                    Dataset ID
+                  </Form.Label>
                   <button
                     type="button"
                     className={style.clearButton}
@@ -524,15 +584,19 @@ const MyDatasets = () => {
               </div>
               {!isAdmin && (
                 <div className={style.primaryFilterBlockScope}>
-                  <Form.Label htmlFor="include-my-groups-filter">Dataset Scope</Form.Label>
+                  <Form.Label htmlFor="include-my-groups-filter">
+                    Dataset Scope
+                  </Form.Label>
                   <Select
                     className={style.datasetScopeSelect}
                     classNamePrefix="datasetScopeSelect"
                     inputId="include-my-groups-filter"
                     isSearchable={false}
-                    value={includeMyGroupsOptions.find((option) => option.value === includeMyGroups)}
-                    onChange={handleIncludeMyGroupsChange}
-                    options={includeMyGroupsOptions}
+                    value={datasetScopeOptions.find(
+                      (option) => option.value === datasetScope
+                    )}
+                    onChange={handleDatasetScopeChange}
+                    options={datasetScopeOptions}
                     components={{ IndicatorSeparator: () => null }}
                     aria-label="Filter by dataset scope"
                   />
@@ -585,7 +649,9 @@ const MyDatasets = () => {
                 <Col md={4} className={style.datasetFilterBlock}>
                   <Form.Group>
                     <div className={style.labelWithClear}>
-                      <Form.Label htmlFor="projectGroup-search">Project Group</Form.Label>
+                      <Form.Label htmlFor="projectGroup-search">
+                        Project Group
+                      </Form.Label>
                       <button
                         type="button"
                         className={style.clearButton}
@@ -615,6 +681,7 @@ const MyDatasets = () => {
                         type="button"
                         className={style.clearButton}
                         onClick={handleClearFilterProjectGroup}
+                        disabled={isCurrentProjectGroupScope}
                         aria-label="Clear project group filter"
                       >
                         Clear
@@ -624,6 +691,17 @@ const MyDatasets = () => {
                       searchText={projectGroupSearchText}
                       setSearchText={setProjectGroupSearchText}
                       onSelectProjectGroup={handleProjectGroupSelect}
+                      defaultProjectGroupId={
+                        isCurrentProjectGroupScope
+                          ? currentProjectGroupId
+                          : undefined
+                      }
+                      defaultProjectGroupName={
+                        isCurrentProjectGroupScope
+                          ? currentProjectGroupName
+                          : undefined
+                      }
+                      disabled={isCurrentProjectGroupScope}
                     />
                   </Form.Group>
                 </Col>


### PR DESCRIPTION
## DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3682/

## Changes Implemented

- Added a new `Dataset Scope` filter for non-admin users in `My Datasets` with these options:
  - `All`
  - `Current Project Group`
  - `My Project Groups`
- Defaulted the dataset scope to `Current Project Group` using the Redux-selected project group.
- Updated dataset query behavior so non-admin requests now derive:
  - the effective project group id from the selected scope
  - the `includeMyGroups` flag based on the chosen scope
- When `Current Project Group` is selected:
  - the project group picker is prefilled with the currently selected project group
  - the picker is disabled/read-only
  - the `Clear` action for project group is disabled
- When switching away from `Current Project Group`:
  - the project group filter is cleared
  - the project group picker becomes editable again
- Updated `ProjectGroupRolesPicker` to support a `disabled` state, prevent focus/input interactions when disabled, and keep the default project group selection in sync.
- Included minor formatting and accessibility cleanup in the touched components.

## Testing Steps

1. Log in as a non-admin user and open `My Datasets`.
2. Verify `Dataset Scope` is visible and defaults to `Current Project Group`.
3. Confirm the `Project Group` field is prefilled with the currently selected project group and cannot be edited in that scope.
4. Confirm the `Clear` button for `Project Group` is disabled in `Current Project Group` scope.
5. Change scope to `All` and verify the project group filter clears and the picker becomes editable.
6. Change scope to `My Project Groups` and verify the picker remains editable and dataset results are restricted to the user’s project groups.
7. Switch back to `Current Project Group` and verify the current project group is restored automatically.
8. Log in as an admin user and verify existing dataset filtering behavior is unchanged and the non-admin scope control does not appear.

## Screenshots:
<img width="1470" height="956" alt="Screenshot 2026-06-26 at 5 07 01 PM" src="https://github.com/user-attachments/assets/727968a0-fafc-4cbb-9d8c-045ff5bde979" />
<img width="1470" height="956" alt="Screenshot 2026-06-26 at 5 07 06 PM" src="https://github.com/user-attachments/assets/fdc6e4a2-364e-4df9-a5d8-4383088e0ea4" />
