### PR TITLE
BugFix-3550: Added a new component for dataset actions menu

### DIFF
--- a/tdei-ui/src/components/AccessibleActionMenu/AccessibleActionMenu.js
+++ b/tdei-ui/src/components/AccessibleActionMenu/AccessibleActionMenu.js
@@ -1,0 +1,187 @@
+import React, { useRef, useState, useCallback, useEffect } from "react";
+import style from "./AccessibleActionMenu.module.css";
+
+
+const AccessibleActionMenu = ({
+  trigger,
+  triggerId,
+  triggerClassName,
+  menuClassName,
+  items = [],
+  onSelect,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const triggerRef = useRef(null);
+  const menuRef = useRef(null);
+  const itemRefs = useRef([]);
+
+  itemRefs.current = items.map(
+    (_, i) => itemRefs.current[i] || React.createRef()
+  );
+
+  const openMenu = useCallback(() => {
+    setIsOpen(true);
+    setActiveIndex(0);
+  }, []);
+
+  const closeMenu = useCallback((returnFocus = true) => {
+    setIsOpen(false);
+    setActiveIndex(-1);
+    if (returnFocus && triggerRef.current) {
+      triggerRef.current.focus();
+    }
+  }, []);
+
+  const selectItem = useCallback(
+    (key) => {
+      closeMenu(true);
+      onSelect && onSelect(key);
+    },
+    [closeMenu, onSelect]
+  );
+
+  // Focus the active item whenever activeIndex or isOpen changes
+  useEffect(() => {
+    if (isOpen && activeIndex >= 0 && itemRefs.current[activeIndex]?.current) {
+      itemRefs.current[activeIndex].current.focus();
+    }
+  }, [isOpen, activeIndex]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (e) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target) &&
+        triggerRef.current &&
+        !triggerRef.current.contains(e.target)
+      ) {
+        closeMenu(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, closeMenu]);
+
+  // Trigger keyboard handler
+  const handleTriggerKeyDown = (e) => {
+    switch (e.key) {
+      case "Enter":
+      case " ":
+      case "ArrowDown":
+        e.preventDefault();
+        openMenu();
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setIsOpen(true);
+        setActiveIndex(items.length - 1);
+        break;
+      default:
+        break;
+    }
+  };
+
+  // Menu item keyboard handler
+  const handleItemKeyDown = (e, index) => {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((index + 1) % items.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((index - 1 + items.length) % items.length);
+        break;
+      case "Home":
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setActiveIndex(items.length - 1);
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        selectItem(items[index].key);
+        break;
+      case "Escape":
+        e.preventDefault();
+        closeMenu(true);
+        break;
+      case "Tab":
+        closeMenu(false);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleTriggerClick = () => {
+    if (isOpen) {
+      closeMenu(false);
+    } else {
+      openMenu();
+    }
+  };
+
+  return (
+    <div className={`${style.menuContainer} ${menuClassName || ""}`}>
+      {/* Menu trigger button */}
+      <button
+        ref={triggerRef}
+        id={triggerId}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-controls={triggerId ? `${triggerId}-menu` : undefined}
+        className={`${style.triggerButton} ${triggerClassName || ""}`}
+        onClick={handleTriggerClick}
+        onKeyDown={handleTriggerKeyDown}
+      >
+        {trigger}
+      </button>
+
+      {/* Dropdown menu */}
+      {isOpen && (
+        <ul
+          ref={menuRef}
+          id={triggerId ? `${triggerId}-menu` : undefined}
+          role="menu"
+          aria-labelledby={triggerId}
+          className={style.menu}
+        >
+          {items.map(({ key, label, icon }, index) => (
+            <li key={key} role="none">
+              <button
+                ref={itemRefs.current[index]}
+                role="menuitem"
+                type="button"
+                tabIndex={activeIndex === index ? 0 : -1}
+                className={style.menuItem}
+                onClick={() => selectItem(key)}
+                onKeyDown={(e) => handleItemKeyDown(e, index)}
+                onMouseEnter={() => setActiveIndex(index)}
+              >
+                {typeof icon === "string" ? (
+                  <img src={icon} className={style.itemIcon} alt="" aria-hidden="true" />
+                ) : (
+                  <span className={style.itemIcon} aria-hidden="true">{icon}</span>
+                )}
+                <span>{label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default AccessibleActionMenu;

--- a/tdei-ui/src/components/AccessibleActionMenu/AccessibleActionMenu.module.css
+++ b/tdei-ui/src/components/AccessibleActionMenu/AccessibleActionMenu.module.css
@@ -1,0 +1,84 @@
+.menuContainer {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+}
+
+.triggerButton {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+}
+
+.triggerButton:hover {
+  background-color: #eeeeee;
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 1000;
+  min-width: 200px;
+  list-style: none;
+  margin: 0;
+  padding: 10px 0;
+  background-color: var(--white);
+  box-shadow: 0px 3px 6px #00000015;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px 15px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: #162848;
+  font-size: 15px;
+  font-family: var(--primary-font-family);
+  transition: background-color 0.1s ease;
+}
+
+.menuItem:hover,
+.menuItem:focus,
+.menuItem:focus-visible {
+  background-color: #f5f5f5;
+  outline: none;
+}
+
+.itemIcon {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 12px;
+  width: 15px;
+  flex-shrink: 0;
+}
+
+.actionButtonTrigger {
+  background-color: transparent;
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  text-decoration: none;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: 4px;
+  width: 50%;
+  margin-top: 10px;
+  justify-content: center;
+}
+
+.actionButtonTrigger:hover {
+  background-color: var(--primary-color);
+  color: var(--white);
+}

--- a/tdei-ui/src/routes/Datasets/DatasetRow.js
+++ b/tdei-ui/src/routes/Datasets/DatasetRow.js
@@ -226,6 +226,7 @@ const DatasetRow = ({ dataset, onAction, isReleasedList }) => {
             isReleasedDataset={isReleasedList}
             data_type={data_type}
             dataViewerProps={dataViewerProps()}
+            datasetId={tdei_dataset_id}
           />
         </div>
         {/* )} */}

--- a/tdei-ui/src/routes/Datasets/DatasetsActions.js
+++ b/tdei-ui/src/routes/Datasets/DatasetsActions.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { Dropdown } from "react-bootstrap";
 import style from "./Datasets.module.css";
 import menuOptionIcon from "../../assets/img/menu-options.svg";
 import releaseIcon from "../../assets/img/action-release.svg";
@@ -19,6 +18,8 @@ import useIsMember from "../../hooks/roles/useIsMember";
 import { useAuth } from "../../hooks/useAuth";
 import useIsDataTypeGenerator from "../../hooks/useIsDataTypeGenerator";
 import { useMediaQuery } from 'react-responsive';
+import AccessibleActionMenu from "../../components/AccessibleActionMenu/AccessibleActionMenu";
+import menuStyle from "../../components/AccessibleActionMenu/AccessibleActionMenu.module.css";
 
 const DatasetsActions = ({
   status,
@@ -26,6 +27,7 @@ const DatasetsActions = ({
   isReleasedDataset,
   data_type,
   dataViewerProps,
+  datasetId,
 }) => {
   const { user } = useAuth();
   const isPocUser = useIsPoc();
@@ -135,41 +137,27 @@ const DatasetsActions = ({
   return (
     actions.length > 0 && (
       <div className={style.dropdownContainer}>
-        <Dropdown onSelect={onAction} className={style.fullWidth}>
-          {isMobile ? (
-            <Dropdown.Toggle
-              id="dropdown-basic"
-              variant="btn btn-link"
-              className={style.datasetActionsButton}
-            >
-              Manage Dataset
-            </Dropdown.Toggle>
-          ) : (
-            <Dropdown.Toggle
-              id="dropdown-basic"
-              variant="btn btn-link"
-              className={style.dropdownToggle}
-            >
+        <AccessibleActionMenu
+          triggerId={`dataset-actions-menu-${datasetId || "default"}`}
+          trigger={
+            isMobile ? (
+              "Manage Dataset"
+            ) : (
               <img
                 src={menuOptionIcon}
                 className={style.moreActionIcon}
                 alt="Manage Dataset Options"
               />
-            </Dropdown.Toggle>
-          )}
-          <Dropdown.Menu className={style.dropdownCard} role="listbox">
-            {actions.map(({ key, label, icon }) => (
-              <Dropdown.Item key={key} eventKey={key} className={style.itemRow} role="option">
-                {typeof icon === "string" ? (
-                  <img src={icon} className={style.itemIcon} alt="" />
-                ) : (
-                  icon
-                )}
-                {label}
-              </Dropdown.Item>
-            ))}
-          </Dropdown.Menu>
-        </Dropdown>
+            )
+          }
+          triggerClassName={
+            isMobile
+              ? `${style.datasetActionsButton} ${menuStyle.actionButtonTrigger}`
+              : style.dropdownToggle
+          }
+          items={actions}
+          onSelect={onAction}
+        />
       </div>
     )
   );


### PR DESCRIPTION
## DevBoard task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3550

## Issue:
The "Manage Dataset" action menu was not keyboard-accessible for screen reader users. Items were only reachable via Shift+Tab, and pressing Enter/Space on the trigger would directly activate the first option ("Open in Workspaces") instead of opening the menu.

## Changes Implemented:
Replaced the React Bootstrap Dropdown with a WAI-ARIA compliant Menu Button component implementing the correct `role="menu"` / `role="menuitem"` pattern. Icons are marked `aria-hidden` so screen readers announce only the label. Styles use existing project theme variables.

## Keyboard Support
| Key | Behaviour |
|-----|-----------|
| `Enter` / `Space` on trigger | Opens menu, focuses first item |
| `↓` / `↑` | Moves focus between items |
| `Enter` / `Space` on item | Selects item, closes menu |
| `Escape` | Closes menu, returns focus to trigger |
| `Tab` | Closes menu |

## Areas Of Testing
1. Open the action menu with a mouse -> confirm all options appear and work as before.
2. Tab to the trigger, press **Enter** -> menu should open without triggering any action.
3. Use **Arrow keys** to navigate items, press **Enter** to select -> correct action should fire.
4. Press **Escape** -> menu should close and focus return to the trigger.
5. Test with VoiceOver (macOS) -> trigger should announce as **"menu button"** arrow keys should read each item label.
