### PR TITLE
Stage to Prod

### DIFF
--- a/tdei-ui/src/components/AccessibleActionMenu/AccessibleActionMenu.js
+++ b/tdei-ui/src/components/AccessibleActionMenu/AccessibleActionMenu.js
@@ -1,0 +1,187 @@
+import React, { useRef, useState, useCallback, useEffect } from "react";
+import style from "./AccessibleActionMenu.module.css";
+
+
+const AccessibleActionMenu = ({
+  trigger,
+  triggerId,
+  triggerClassName,
+  menuClassName,
+  items = [],
+  onSelect,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const triggerRef = useRef(null);
+  const menuRef = useRef(null);
+  const itemRefs = useRef([]);
+
+  itemRefs.current = items.map(
+    (_, i) => itemRefs.current[i] || React.createRef()
+  );
+
+  const openMenu = useCallback(() => {
+    setIsOpen(true);
+    setActiveIndex(0);
+  }, []);
+
+  const closeMenu = useCallback((returnFocus = true) => {
+    setIsOpen(false);
+    setActiveIndex(-1);
+    if (returnFocus && triggerRef.current) {
+      triggerRef.current.focus();
+    }
+  }, []);
+
+  const selectItem = useCallback(
+    (key) => {
+      closeMenu(true);
+      onSelect && onSelect(key);
+    },
+    [closeMenu, onSelect]
+  );
+
+  // Focus the active item whenever activeIndex or isOpen changes
+  useEffect(() => {
+    if (isOpen && activeIndex >= 0 && itemRefs.current[activeIndex]?.current) {
+      itemRefs.current[activeIndex].current.focus();
+    }
+  }, [isOpen, activeIndex]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (e) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target) &&
+        triggerRef.current &&
+        !triggerRef.current.contains(e.target)
+      ) {
+        closeMenu(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, closeMenu]);
+
+  // Trigger keyboard handler
+  const handleTriggerKeyDown = (e) => {
+    switch (e.key) {
+      case "Enter":
+      case " ":
+      case "ArrowDown":
+        e.preventDefault();
+        openMenu();
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setIsOpen(true);
+        setActiveIndex(items.length - 1);
+        break;
+      default:
+        break;
+    }
+  };
+
+  // Menu item keyboard handler
+  const handleItemKeyDown = (e, index) => {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((index + 1) % items.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((index - 1 + items.length) % items.length);
+        break;
+      case "Home":
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setActiveIndex(items.length - 1);
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        selectItem(items[index].key);
+        break;
+      case "Escape":
+        e.preventDefault();
+        closeMenu(true);
+        break;
+      case "Tab":
+        closeMenu(false);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleTriggerClick = () => {
+    if (isOpen) {
+      closeMenu(false);
+    } else {
+      openMenu();
+    }
+  };
+
+  return (
+    <div className={`${style.menuContainer} ${menuClassName || ""}`}>
+      {/* Menu trigger button */}
+      <button
+        ref={triggerRef}
+        id={triggerId}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-controls={triggerId ? `${triggerId}-menu` : undefined}
+        className={`${style.triggerButton} ${triggerClassName || ""}`}
+        onClick={handleTriggerClick}
+        onKeyDown={handleTriggerKeyDown}
+      >
+        {trigger}
+      </button>
+
+      {/* Dropdown menu */}
+      {isOpen && (
+        <ul
+          ref={menuRef}
+          id={triggerId ? `${triggerId}-menu` : undefined}
+          role="menu"
+          aria-labelledby={triggerId}
+          className={style.menu}
+        >
+          {items.map(({ key, label, icon }, index) => (
+            <li key={key} role="none">
+              <button
+                ref={itemRefs.current[index]}
+                role="menuitem"
+                type="button"
+                tabIndex={activeIndex === index ? 0 : -1}
+                className={style.menuItem}
+                onClick={() => selectItem(key)}
+                onKeyDown={(e) => handleItemKeyDown(e, index)}
+                onMouseEnter={() => setActiveIndex(index)}
+              >
+                {typeof icon === "string" ? (
+                  <img src={icon} className={style.itemIcon} alt="" aria-hidden="true" />
+                ) : (
+                  <span className={style.itemIcon} aria-hidden="true">{icon}</span>
+                )}
+                <span>{label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default AccessibleActionMenu;

--- a/tdei-ui/src/components/AccessibleActionMenu/AccessibleActionMenu.module.css
+++ b/tdei-ui/src/components/AccessibleActionMenu/AccessibleActionMenu.module.css
@@ -1,0 +1,84 @@
+.menuContainer {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+}
+
+.triggerButton {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+}
+
+.triggerButton:hover {
+  background-color: #eeeeee;
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 1000;
+  min-width: 200px;
+  list-style: none;
+  margin: 0;
+  padding: 10px 0;
+  background-color: var(--white);
+  box-shadow: 0px 3px 6px #00000015;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px 15px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: #162848;
+  font-size: 15px;
+  font-family: var(--primary-font-family);
+  transition: background-color 0.1s ease;
+}
+
+.menuItem:hover,
+.menuItem:focus,
+.menuItem:focus-visible {
+  background-color: #f5f5f5;
+  outline: none;
+}
+
+.itemIcon {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 12px;
+  width: 15px;
+  flex-shrink: 0;
+}
+
+.actionButtonTrigger {
+  background-color: transparent;
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  text-decoration: none;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: 4px;
+  width: 50%;
+  margin-top: 10px;
+  justify-content: center;
+}
+
+.actionButtonTrigger:hover {
+  background-color: var(--primary-color);
+  color: var(--white);
+}

--- a/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.js
+++ b/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.js
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
 import { Form, Spinner, InputGroup } from "react-bootstrap";
 import useGetProjectGroupRoles from "../../hooks/roles/useProjectGroupRoles";
 import styles from "./ProjectGroupRolesPicker.module.css";
@@ -10,13 +16,13 @@ const ProjectGroupRolesPicker = ({
   onSelectProjectGroup,
   defaultProjectGroupId,
   defaultProjectGroupName,
+  disabled = false,
 }) => {
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [selectedGroup, setSelectedGroup] = useState(null);
   const [showDropdown, setShowDropdown] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [announcement, setAnnouncement] = useState("");
-  const [initialized, setInitialized] = useState(false);
 
   const autocompleteRef = useRef();
   const listRef = useRef();
@@ -33,15 +39,25 @@ const ProjectGroupRolesPicker = ({
   }, [data]);
 
   useEffect(() => {
-    if (!initialized && defaultProjectGroupId && defaultProjectGroupName) {
+    if (
+      defaultProjectGroupId &&
+      defaultProjectGroupName &&
+      (disabled || searchText === "")
+    ) {
       setSelectedGroup({
         tdei_project_group_id: defaultProjectGroupId,
         project_group_name: defaultProjectGroupName,
       });
       setSearchText(defaultProjectGroupName);
-      setInitialized(true);
+      setShowDropdown(false);
     }
-  }, [defaultProjectGroupId, defaultProjectGroupName, initialized, setSearchText]);
+  }, [
+    defaultProjectGroupId,
+    defaultProjectGroupName,
+    disabled,
+    searchText,
+    setSearchText,
+  ]);
 
   useEffect(() => {
     if (searchText === "") {
@@ -56,7 +72,12 @@ const ProjectGroupRolesPicker = ({
       }
       setShowDropdown(false);
     }
-  }, [searchText, defaultProjectGroupId, defaultProjectGroupName, setSearchText]);
+  }, [
+    searchText,
+    defaultProjectGroupId,
+    defaultProjectGroupName,
+    setSearchText,
+  ]);
 
   const debouncedSearch = useMemo(
     () => debounce((value) => setDebouncedQuery(value), 150),
@@ -64,6 +85,8 @@ const ProjectGroupRolesPicker = ({
   );
 
   const handleInputChange = (e) => {
+    if (disabled) return;
+
     const value = e.target.value;
     setSearchText(value);
     if (value.trim() === "") {
@@ -117,7 +140,9 @@ const ProjectGroupRolesPicker = ({
   useEffect(() => {
     if (showDropdown && !isLoading && projectGroups.length > 0) {
       setAnnouncement(
-        `${projectGroups.length} result${projectGroups.length === 1 ? "" : "s"} available. Use arrow keys to navigate.`
+        `${projectGroups.length} result${
+          projectGroups.length === 1 ? "" : "s"
+        } available. Use arrow keys to navigate.`
       );
     } else if (showDropdown && !isLoading && projectGroups.length === 0) {
       setAnnouncement("No project groups found.");
@@ -127,7 +152,10 @@ const ProjectGroupRolesPicker = ({
   }, [showDropdown, isLoading, projectGroups.length]);
 
   const handleClickOutside = useCallback((e) => {
-    if (autocompleteRef.current && !autocompleteRef.current.contains(e.target)) {
+    if (
+      autocompleteRef.current &&
+      !autocompleteRef.current.contains(e.target)
+    ) {
       setShowDropdown(false);
     }
   }, []);
@@ -171,7 +199,9 @@ const ProjectGroupRolesPicker = ({
           placeholder="Search Project Group"
           onChange={handleInputChange}
           value={selectedGroup ? selectedGroup.project_group_name : searchText}
+          disabled={disabled}
           onFocus={() => {
+            if (disabled) return;
             setDebouncedQuery("");
             setShowDropdown(true);
           }}
@@ -187,7 +217,11 @@ const ProjectGroupRolesPicker = ({
         />
         {isLoading && (
           <InputGroup.Text>
-            <Spinner animation="border" size="sm" aria-label="Loading results" />
+            <Spinner
+              animation="border"
+              size="sm"
+              aria-label="Loading results"
+            />
           </InputGroup.Text>
         )}
       </InputGroup>
@@ -204,7 +238,8 @@ const ProjectGroupRolesPicker = ({
           {projectGroups.map((group, index) => {
             const optionId = `pg-option-${group.tdei_project_group_id}`;
             const isSelected =
-              selectedGroup?.tdei_project_group_id === group.tdei_project_group_id;
+              selectedGroup?.tdei_project_group_id ===
+              group.tdei_project_group_id;
             return (
               <div
                 key={group.tdei_project_group_id}

--- a/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.js
+++ b/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.js
@@ -1,0 +1,238 @@
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { Form, Spinner, InputGroup } from "react-bootstrap";
+import useGetProjectGroupRoles from "../../hooks/roles/useProjectGroupRoles";
+import styles from "./ProjectGroupRolesPicker.module.css";
+import { debounce } from "lodash";
+
+const ProjectGroupRolesPicker = ({
+  searchText,
+  setSearchText,
+  onSelectProjectGroup,
+  defaultProjectGroupId,
+  defaultProjectGroupName,
+}) => {
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [selectedGroup, setSelectedGroup] = useState(null);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [announcement, setAnnouncement] = useState("");
+  const [initialized, setInitialized] = useState(false);
+
+  const autocompleteRef = useRef();
+  const listRef = useRef();
+
+  const { data, isLoading } = useGetProjectGroupRoles(debouncedQuery);
+
+  const projectGroups = useMemo(() => {
+    const seen = new Set();
+    return (data?.pages?.flatMap((page) => page.data) || []).filter((pg) => {
+      if (seen.has(pg.tdei_project_group_id)) return false;
+      seen.add(pg.tdei_project_group_id);
+      return true;
+    });
+  }, [data]);
+
+  useEffect(() => {
+    if (!initialized && defaultProjectGroupId && defaultProjectGroupName) {
+      setSelectedGroup({
+        tdei_project_group_id: defaultProjectGroupId,
+        project_group_name: defaultProjectGroupName,
+      });
+      setSearchText(defaultProjectGroupName);
+      setInitialized(true);
+    }
+  }, [defaultProjectGroupId, defaultProjectGroupName, initialized, setSearchText]);
+
+  useEffect(() => {
+    if (searchText === "") {
+      if (defaultProjectGroupId && defaultProjectGroupName) {
+        setSelectedGroup({
+          tdei_project_group_id: defaultProjectGroupId,
+          project_group_name: defaultProjectGroupName,
+        });
+        setSearchText(defaultProjectGroupName);
+      } else {
+        setSelectedGroup(null);
+      }
+      setShowDropdown(false);
+    }
+  }, [searchText, defaultProjectGroupId, defaultProjectGroupName, setSearchText]);
+
+  const debouncedSearch = useMemo(
+    () => debounce((value) => setDebouncedQuery(value), 150),
+    []
+  );
+
+  const handleInputChange = (e) => {
+    const value = e.target.value;
+    setSearchText(value);
+    if (value.trim() === "") {
+      setSelectedGroup(null);
+      onSelectProjectGroup(null);
+      setShowDropdown(false);
+      return;
+    }
+    debouncedSearch(value);
+    setShowDropdown(true);
+    setHighlightedIndex(-1);
+  };
+
+  const handleSelect = (group) => {
+    setSelectedGroup(group);
+    setSearchText(group.project_group_name);
+    setShowDropdown(false);
+    setHighlightedIndex(-1);
+    onSelectProjectGroup(group.tdei_project_group_id);
+  };
+
+  const handleKeyDown = (e) => {
+    if (!showDropdown || projectGroups.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        prev < projectGroups.length - 1 ? prev + 1 : prev
+      );
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (highlightedIndex >= 0 && projectGroups[highlightedIndex]) {
+        handleSelect(projectGroups[highlightedIndex]);
+      }
+    } else if (e.key === "Escape" || e.key === "Tab") {
+      if (e.key === "Tab") e.preventDefault();
+      setShowDropdown(false);
+      setHighlightedIndex(-1);
+    }
+  };
+
+  useEffect(() => {
+    if (highlightedIndex >= 0 && listRef.current) {
+      const item = listRef.current.children[highlightedIndex];
+      if (item) item.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlightedIndex]);
+
+  useEffect(() => {
+    if (showDropdown && !isLoading && projectGroups.length > 0) {
+      setAnnouncement(
+        `${projectGroups.length} result${projectGroups.length === 1 ? "" : "s"} available. Use arrow keys to navigate.`
+      );
+    } else if (showDropdown && !isLoading && projectGroups.length === 0) {
+      setAnnouncement("No project groups found.");
+    } else {
+      setAnnouncement("");
+    }
+  }, [showDropdown, isLoading, projectGroups.length]);
+
+  const handleClickOutside = useCallback((e) => {
+    if (autocompleteRef.current && !autocompleteRef.current.contains(e.target)) {
+      setShowDropdown(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      debouncedSearch.cancel();
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [handleClickOutside, debouncedSearch]);
+
+  const listboxId = "project-group-roles-listbox";
+  const activeDescendant =
+    highlightedIndex >= 0 && projectGroups[highlightedIndex]
+      ? `pg-option-${projectGroups[highlightedIndex].tdei_project_group_id}`
+      : undefined;
+  const isExpanded = showDropdown && projectGroups.length > 0;
+
+  return (
+    <div className={styles.autocompleteContainer} ref={autocompleteRef}>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: "absolute",
+          width: "1px",
+          height: "1px",
+          overflow: "hidden",
+          clip: "rect(0,0,0,0)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {announcement}
+      </div>
+
+      <InputGroup>
+        <Form.Control
+          type="text"
+          placeholder="Search Project Group"
+          onChange={handleInputChange}
+          value={selectedGroup ? selectedGroup.project_group_name : searchText}
+          onFocus={() => {
+            setDebouncedQuery("");
+            setShowDropdown(true);
+          }}
+          onKeyDown={handleKeyDown}
+          autoComplete="off"
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded={isExpanded}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={activeDescendant}
+          aria-label="Search Project Group"
+        />
+        {isLoading && (
+          <InputGroup.Text>
+            <Spinner animation="border" size="sm" aria-label="Loading results" />
+          </InputGroup.Text>
+        )}
+      </InputGroup>
+
+      {showDropdown && projectGroups.length > 0 && (
+        <div
+          role="listbox"
+          id={listboxId}
+          aria-label="Project Groups"
+          className={styles.dropdownList}
+          ref={listRef}
+          tabIndex="-1"
+        >
+          {projectGroups.map((group, index) => {
+            const optionId = `pg-option-${group.tdei_project_group_id}`;
+            const isSelected =
+              selectedGroup?.tdei_project_group_id === group.tdei_project_group_id;
+            return (
+              <div
+                key={group.tdei_project_group_id}
+                id={optionId}
+                role="option"
+                aria-selected={isSelected}
+                className={`${styles.dropdownItem} ${
+                  highlightedIndex === index
+                    ? styles.highlighted
+                    : isSelected
+                    ? styles.active
+                    : ""
+                }`}
+                onClick={() => handleSelect(group)}
+              >
+                {group.project_group_name}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {showDropdown && projectGroups.length === 0 && !isLoading && (
+        <div className={styles.noResults} role="status">
+          No project groups found.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default React.memo(ProjectGroupRolesPicker);

--- a/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.module.css
+++ b/tdei-ui/src/components/ProjectGroupRolesPicker/ProjectGroupRolesPicker.module.css
@@ -1,0 +1,43 @@
+.autocompleteContainer {
+  position: relative;
+  width: 100%;
+}
+
+.dropdownList {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #ced4da;
+  border-top: none;
+  background-color: #fff;
+  z-index: 1000;
+  outline: none;
+}
+
+.dropdownItem {
+  padding: 8px 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.dropdownItem:hover {
+  background-color: #f8f9fa;
+}
+
+.active {
+  background-color: #f8f9fa;
+}
+
+.highlighted,
+.highlighted:hover {
+  background-color: #deebff;
+  outline: none;
+}
+
+.noResults {
+  padding: 8px 12px;
+  color: #6c757d;
+}

--- a/tdei-ui/src/hooks/service/useGetDatasets.js
+++ b/tdei-ui/src/hooks/service/useGetDatasets.js
@@ -1,18 +1,15 @@
 import { useInfiniteQuery } from "react-query";
 import { useState } from "react";
-import { useSelector } from "react-redux";
-import { getSelectedProjectGroup } from "../../selectors";
 import { GET_DATASETS } from "../../utils";
 import { getDatasets } from "../../services";
 
-function useGetDatasets(isAdmin, searchText = "", searchDatasetId = "",status = "All", dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId,sortField, sortOrder) {
-  const { tdei_project_group_id } = useSelector(getSelectedProjectGroup);
+function useGetDatasets(isAdmin, searchText = "", searchDatasetId = "",status = "All", dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId, includeMyGroups, sortField, sortOrder) {
   const [refreshKey, setRefreshKey] = useState(0); // for refreshing data
   
   const { data, isError, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery(
-    [GET_DATASETS, searchText,searchDatasetId, status, dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId, tdei_project_group_id, sortField, sortOrder,refreshKey],
+    [GET_DATASETS, isAdmin, searchText,searchDatasetId, status, dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId, includeMyGroups, sortField, sortOrder,refreshKey],
     ({ pageParam }) =>
-      getDatasets(searchText,searchDatasetId, pageParam, isAdmin, status, dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId, tdei_project_group_id,sortField,sortOrder),
+      getDatasets(searchText,searchDatasetId, pageParam, isAdmin, status, dataType, validFrom, validTo, tdeiServiceId, selectedProjectGroupId, includeMyGroups, sortField,sortOrder),
     {
       getNextPageParam: (lastPage) => {
         return lastPage.data.length > 0 && lastPage.data.length === 10

--- a/tdei-ui/src/routes/Datasets/DatasetRow.js
+++ b/tdei-ui/src/routes/Datasets/DatasetRow.js
@@ -226,6 +226,7 @@ const DatasetRow = ({ dataset, onAction, isReleasedList }) => {
             isReleasedDataset={isReleasedList}
             data_type={data_type}
             dataViewerProps={dataViewerProps()}
+            datasetId={tdei_dataset_id}
           />
         </div>
         {/* )} */}

--- a/tdei-ui/src/routes/Datasets/Datasets.module.css
+++ b/tdei-ui/src/routes/Datasets/Datasets.module.css
@@ -321,7 +321,8 @@
   width: 40px;
   height: 40px;
   margin-top: 30px !important;
-  margin-right: 15px !important;
+  margin-right: 0 !important;
+  flex: 0 0 40px;
 }
 .sortByField {
   width: 300px;
@@ -341,7 +342,8 @@
   border: 1px solid #CED4DA !important;
   border-radius: 8px !important;
   opacity: 1 !important; 
-  width: 120px;
+  width: 104px;
+  min-width: 104px !important;
   height: 40px;
   margin-top: 30px !important;
   color: black !important;
@@ -388,15 +390,36 @@
     flex: 1 1 0;
     min-width: 0;
   }
+  .primaryFilterBlockScope {
+    flex: 1 1 0;
+    min-width: 0;
+  }
   .primaryFilterBlock_Released {
     flex: 1 1 0;
     min-width: 0;
   }
 }
+.datasetScopeSelect {
+  width: 100%;
+}
+.datasetScopeSelect :global(.datasetScopeSelect__control) {
+  border: 1px solid #ced4da;
+  border-radius: 0.375rem;
+  min-height: calc(1.5em + 0.75rem + 2px);
+  box-shadow: none;
+}
+.datasetScopeSelect :global(.datasetScopeSelect__control:hover) {
+  border-color: #ced4da;
+}
+.datasetScopeSelect :global(.datasetScopeSelect__control--is-focused) {
+  border-color: #86b7fe;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
 .secondaryFilterContainer {
   display: flex;
   justify-content: flex-end;
-  gap: 15px;
+  flex-wrap: nowrap;
+  gap: 10px;
 }
 .typeNameTransform {
   text-transform: uppercase;
@@ -471,6 +494,11 @@
     align-items: stretch;
     .primaryFilterBlock {
       width: 100%;
+      flex: none;
+    }
+    .primaryFilterBlockScope {
+      width: 100%;
+      min-width: 0;
       flex: none;
     }
     .primaryFilterBlock_Released {

--- a/tdei-ui/src/routes/Datasets/DatasetsActions.js
+++ b/tdei-ui/src/routes/Datasets/DatasetsActions.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { Dropdown } from "react-bootstrap";
 import style from "./Datasets.module.css";
 import menuOptionIcon from "../../assets/img/menu-options.svg";
 import releaseIcon from "../../assets/img/action-release.svg";
@@ -19,6 +18,8 @@ import useIsMember from "../../hooks/roles/useIsMember";
 import { useAuth } from "../../hooks/useAuth";
 import useIsDataTypeGenerator from "../../hooks/useIsDataTypeGenerator";
 import { useMediaQuery } from 'react-responsive';
+import AccessibleActionMenu from "../../components/AccessibleActionMenu/AccessibleActionMenu";
+import menuStyle from "../../components/AccessibleActionMenu/AccessibleActionMenu.module.css";
 
 const DatasetsActions = ({
   status,
@@ -26,6 +27,7 @@ const DatasetsActions = ({
   isReleasedDataset,
   data_type,
   dataViewerProps,
+  datasetId,
 }) => {
   const { user } = useAuth();
   const isPocUser = useIsPoc();
@@ -135,41 +137,27 @@ const DatasetsActions = ({
   return (
     actions.length > 0 && (
       <div className={style.dropdownContainer}>
-        <Dropdown onSelect={onAction} className={style.fullWidth}>
-          {isMobile ? (
-            <Dropdown.Toggle
-              id="dropdown-basic"
-              variant="btn btn-link"
-              className={style.datasetActionsButton}
-            >
-              Manage Dataset
-            </Dropdown.Toggle>
-          ) : (
-            <Dropdown.Toggle
-              id="dropdown-basic"
-              variant="btn btn-link"
-              className={style.dropdownToggle}
-            >
+        <AccessibleActionMenu
+          triggerId={`dataset-actions-menu-${datasetId || "default"}`}
+          trigger={
+            isMobile ? (
+              "Manage Dataset"
+            ) : (
               <img
                 src={menuOptionIcon}
                 className={style.moreActionIcon}
                 alt="Manage Dataset Options"
               />
-            </Dropdown.Toggle>
-          )}
-          <Dropdown.Menu className={style.dropdownCard} role="listbox">
-            {actions.map(({ key, label, icon }) => (
-              <Dropdown.Item key={key} eventKey={key} className={style.itemRow} role="option">
-                {typeof icon === "string" ? (
-                  <img src={icon} className={style.itemIcon} alt="" />
-                ) : (
-                  icon
-                )}
-                {label}
-              </Dropdown.Item>
-            ))}
-          </Dropdown.Menu>
-        </Dropdown>
+            )
+          }
+          triggerClassName={
+            isMobile
+              ? `${style.datasetActionsButton} ${menuStyle.actionButtonTrigger}`
+              : style.dropdownToggle
+          }
+          items={actions}
+          onSelect={onAction}
+        />
       </div>
     )
   );

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -26,6 +26,9 @@ import ServiceAutocomplete from "../../components/ServiceAutocomplete/ServiceAut
 import DownloadModal from "../../components/DownloadModal/DownloadModal";
 import useCreateQualityReportJob from "../../hooks/jobs/useCreateQualityReportJob";
 import { buildShareDatasetPath } from "../../utils";
+import { useSelector } from "react-redux";
+import { getSelectedProjectGroup } from "../../selectors";
+import ProjectGroupRolesPicker from "../../components/ProjectGroupRolesPicker/ProjectGroupRolesPicker";
 
 const MyDatasets = () => {
   const queryClient = useQueryClient();
@@ -47,7 +50,11 @@ const MyDatasets = () => {
   const [eventKey, setEventKey] = useState("");
   const [operationResult, setOperationResult] = useState("");
   const isAdmin = user && user.isAdmin;
+  const selectedProjectGroup = useSelector(getSelectedProjectGroup);
   const [selectedProjectGroupId, setSelectedProjectGroupId] = useState(null);
+  // Filter override for non-admin users: null means use the Redux selected project group
+  const [nonAdminProjectGroupId, setNonAdminProjectGroupId] = useState(null);
+  // The project group ID to pass to useGetDatasets for non-admins (null = use Redux default)
   const [sortField, setSortField] = useState("uploaded_timestamp");
   const [sortOrder, setSortOrder] = useState("DESC");
   const [showDownloadModal, setShowDownloadModal] = useState(false);
@@ -70,12 +77,13 @@ const MyDatasets = () => {
     validFrom,
     validTo,
     tdeiServiceId,
-    selectedProjectGroupId,
+    isAdmin ? selectedProjectGroupId : nonAdminProjectGroupId,
     sortField,
     sortOrder
   );
   const [projectSearchText, setProjectSearchText] = useState("");
   const [serviceSearchText, setServiceSearchText] = useState("");
+  const [projectGroupSearchText, setProjectGroupSearchText] = useState("");
   const navigate = useNavigate();
   const [customErrorMessage, setCustomErrorMessage] = useState("");
   const [showFilters, setShowFilters] = useState(false);
@@ -93,6 +101,18 @@ const MyDatasets = () => {
     setServiceSearchText("");
     refreshData();
   };
+  const handleClearFilterProjectGroup = () => {
+    setNonAdminProjectGroupId(null);
+    setProjectGroupSearchText("");
+    refreshData();
+  };
+  const handleProjectGroupSelect = useCallback(
+    (projectGroupId) => {
+      setNonAdminProjectGroupId(projectGroupId || null);
+      refreshData();
+    },
+    [refreshData]
+  );
 
   useEffect(() => {
     if (data && data.pages && data.pages.length > 0) {
@@ -567,6 +587,32 @@ const MyDatasets = () => {
                 <Col md={4} className={style.datasetFilterBlock}>
                   <Form.Group>
                     <div className={style.labelWithClear}>
+                      <Form.Label>Project Group</Form.Label>
+                      <button
+                        type="button"
+                        className={style.clearButton}
+                        onClick={handleClearFilterProjectGroup}
+                        aria-label="Clear project group filter"
+                      >
+                        Clear
+                      </button>
+                    </div>
+                    <ProjectGroupRolesPicker
+                      searchText={projectGroupSearchText}
+                      setSearchText={setProjectGroupSearchText}
+                      onSelectProjectGroup={handleProjectGroupSelect}
+                      defaultProjectGroupId={selectedProjectGroup?.tdei_project_group_id}
+                      defaultProjectGroupName={selectedProjectGroup?.name}
+                    />
+                  </Form.Group>
+                </Col>
+              )}
+            </Row>
+            <Row className="">
+              {isAdmin && (
+                <Col md={4} className={style.datasetFilterBlock}>
+                  <Form.Group>
+                    <div className={style.labelWithClear}>
                       <Form.Label htmlFor="service-search">Service</Form.Label>
                       <button
                         type="button"
@@ -586,9 +632,7 @@ const MyDatasets = () => {
                   </Form.Group>
                 </Col>
               )}
-            </Row>
-            <Row className="">
-              {isAdmin && (
+              {!isAdmin && (
                 <Col md={4} className={style.datasetFilterBlock}>
                   <Form.Group>
                     <div className={style.labelWithClear}>

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -3,7 +3,7 @@ import DatasetTableHeader from "./DatasetTableHeader";
 import DatasetRow from "./DatasetRow";
 import { useQueryClient } from "react-query";
 import useGetDatasets from "../../hooks/service/useGetDatasets";
-import { GET_DATASETS, PUBLISH_DATASETS } from "../../utils";
+import { GET_DATASETS } from "../../utils";
 import { debounce } from "lodash";
 import style from "./Datasets.module.css";
 import Select from "react-select";
@@ -26,8 +26,6 @@ import ServiceAutocomplete from "../../components/ServiceAutocomplete/ServiceAut
 import DownloadModal from "../../components/DownloadModal/DownloadModal";
 import useCreateQualityReportJob from "../../hooks/jobs/useCreateQualityReportJob";
 import { buildShareDatasetPath } from "../../utils";
-import { useSelector } from "react-redux";
-import { getSelectedProjectGroup } from "../../selectors";
 import ProjectGroupRolesPicker from "../../components/ProjectGroupRolesPicker/ProjectGroupRolesPicker";
 
 const MyDatasets = () => {
@@ -50,11 +48,9 @@ const MyDatasets = () => {
   const [eventKey, setEventKey] = useState("");
   const [operationResult, setOperationResult] = useState("");
   const isAdmin = user && user.isAdmin;
-  const selectedProjectGroup = useSelector(getSelectedProjectGroup);
   const [selectedProjectGroupId, setSelectedProjectGroupId] = useState(null);
-  // Filter override for non-admin users: null means use the Redux selected project group
   const [nonAdminProjectGroupId, setNonAdminProjectGroupId] = useState(null);
-  // The project group ID to pass to useGetDatasets for non-admins (null = use Redux default)
+  const [includeMyGroups, setIncludeMyGroups] = useState(true);
   const [sortField, setSortField] = useState("uploaded_timestamp");
   const [sortOrder, setSortOrder] = useState("DESC");
   const [showDownloadModal, setShowDownloadModal] = useState(false);
@@ -78,6 +74,7 @@ const MyDatasets = () => {
     validTo,
     tdeiServiceId,
     isAdmin ? selectedProjectGroupId : nonAdminProjectGroupId,
+    isAdmin ? undefined : includeMyGroups,
     sortField,
     sortOrder
   );
@@ -136,6 +133,11 @@ const MyDatasets = () => {
     setStatus(list.value);
   };
 
+  const handleIncludeMyGroupsChange = (option) => {
+    setIncludeMyGroups(option?.value ?? true);
+    refreshData();
+  };
+
   const handleSearch = (e) => {
     setDebounceQuery(e.target.value);
   };
@@ -174,6 +176,11 @@ const MyDatasets = () => {
     { value: "All", label: "All" },
     { value: "Publish", label: "Released" },
     { value: "Pre-Release", label: "Pre-Release" },
+  ];
+
+  const includeMyGroupsOptions = [
+    { value: false, label: "All" },
+    { value: true, label: "My Project Groups" }
   ];
 
   const onSuccess = () => {
@@ -461,7 +468,7 @@ const MyDatasets = () => {
     <div>
       <Form noValidate>
         <Row className="my-3 gx-0">
-          <Col md={12} lg={8}>
+          <Col md={12} xxl={isAdmin ? 8 : 9}>
             <Form.Group className={style.primaryFilterContainer}>
               <div className={style.primaryFilterBlock}>
                 <div className={style.labelWithClear}>
@@ -515,9 +522,25 @@ const MyDatasets = () => {
                   }}
                 />
               </div>
+              {!isAdmin && (
+                <div className={style.primaryFilterBlockScope}>
+                  <Form.Label htmlFor="include-my-groups-filter">Dataset Scope</Form.Label>
+                  <Select
+                    className={style.datasetScopeSelect}
+                    classNamePrefix="datasetScopeSelect"
+                    inputId="include-my-groups-filter"
+                    isSearchable={false}
+                    value={includeMyGroupsOptions.find((option) => option.value === includeMyGroups)}
+                    onChange={handleIncludeMyGroupsChange}
+                    options={includeMyGroupsOptions}
+                    components={{ IndicatorSeparator: () => null }}
+                    aria-label="Filter by dataset scope"
+                  />
+                </div>
+              )}
             </Form.Group>
           </Col>
-          <Col md={12} lg={4}>
+          <Col md={12} xxl={isAdmin ? 4 : 3}>
             <SortRefreshComponent
               handleRefresh={handleRefresh}
               handleSortChange={handleSortChange}

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -27,10 +27,17 @@ import DownloadModal from "../../components/DownloadModal/DownloadModal";
 import useCreateQualityReportJob from "../../hooks/jobs/useCreateQualityReportJob";
 import { buildShareDatasetPath } from "../../utils";
 import ProjectGroupRolesPicker from "../../components/ProjectGroupRolesPicker/ProjectGroupRolesPicker";
+import { useSelector } from "react-redux";
+import { getSelectedProjectGroup } from "../../selectors";
+
+const CURRENT_PROJECT_GROUP_SCOPE = "currentProjectGroup";
+const ALL_DATASETS_SCOPE = "all";
+const MY_PROJECT_GROUPS_SCOPE = "myProjectGroups";
 
 const MyDatasets = () => {
   const queryClient = useQueryClient();
   const { user } = useAuth();
+  const selectedProjectGroup = useSelector(getSelectedProjectGroup);
   const [isLoadingDownload, setIsLoadingDownload] = useState(false);
   const [query, setQuery] = useState("");
   const [debounceQuery, setDebounceQuery] = useState("");
@@ -50,12 +57,27 @@ const MyDatasets = () => {
   const isAdmin = user && user.isAdmin;
   const [selectedProjectGroupId, setSelectedProjectGroupId] = useState(null);
   const [nonAdminProjectGroupId, setNonAdminProjectGroupId] = useState(null);
-  const [includeMyGroups, setIncludeMyGroups] = useState(true);
+  const [datasetScope, setDatasetScope] = useState(CURRENT_PROJECT_GROUP_SCOPE);
   const [sortField, setSortField] = useState("uploaded_timestamp");
   const [sortOrder, setSortOrder] = useState("DESC");
   const [showDownloadModal, setShowDownloadModal] = useState(false);
   const [selectedFormat, setSelectedFormat] = useState(null);
   const [selectedFileVersion, setSelectedFileVersion] = useState(null);
+  const currentProjectGroupId =
+    selectedProjectGroup?.tdei_project_group_id ?? null;
+  const currentProjectGroupName = selectedProjectGroup?.name ?? "";
+  const isCurrentProjectGroupScope =
+    datasetScope === CURRENT_PROJECT_GROUP_SCOPE;
+  const effectiveNonAdminProjectGroupId = isCurrentProjectGroupScope
+    ? currentProjectGroupId
+    : nonAdminProjectGroupId;
+  const includeMyGroups = isAdmin
+    ? undefined
+    : datasetScope === MY_PROJECT_GROUPS_SCOPE
+    ? true
+    : datasetScope === ALL_DATASETS_SCOPE
+    ? false
+    : undefined;
   const {
     data = [],
     isError,
@@ -73,7 +95,7 @@ const MyDatasets = () => {
     validFrom,
     validTo,
     tdeiServiceId,
-    isAdmin ? selectedProjectGroupId : nonAdminProjectGroupId,
+    isAdmin ? selectedProjectGroupId : effectiveNonAdminProjectGroupId,
     isAdmin ? undefined : includeMyGroups,
     sortField,
     sortOrder
@@ -99,8 +121,13 @@ const MyDatasets = () => {
     refreshData();
   };
   const handleClearFilterProjectGroup = () => {
-    setNonAdminProjectGroupId(null);
-    setProjectGroupSearchText("");
+    if (isCurrentProjectGroupScope) {
+      setNonAdminProjectGroupId(currentProjectGroupId);
+      setProjectGroupSearchText(currentProjectGroupName);
+    } else {
+      setNonAdminProjectGroupId(null);
+      setProjectGroupSearchText("");
+    }
     refreshData();
   };
   const handleProjectGroupSelect = useCallback(
@@ -110,6 +137,18 @@ const MyDatasets = () => {
     },
     [refreshData]
   );
+
+  useEffect(() => {
+    if (!isAdmin && isCurrentProjectGroupScope) {
+      setNonAdminProjectGroupId(currentProjectGroupId);
+      setProjectGroupSearchText(currentProjectGroupName);
+    }
+  }, [
+    isAdmin,
+    isCurrentProjectGroupScope,
+    currentProjectGroupId,
+    currentProjectGroupName,
+  ]);
 
   useEffect(() => {
     if (data && data.pages && data.pages.length > 0) {
@@ -133,8 +172,18 @@ const MyDatasets = () => {
     setStatus(list.value);
   };
 
-  const handleIncludeMyGroupsChange = (option) => {
-    setIncludeMyGroups(option?.value ?? true);
+  const handleDatasetScopeChange = (option) => {
+    const nextScope = option?.value ?? CURRENT_PROJECT_GROUP_SCOPE;
+    setDatasetScope(nextScope);
+
+    if (nextScope === CURRENT_PROJECT_GROUP_SCOPE) {
+      setNonAdminProjectGroupId(currentProjectGroupId);
+      setProjectGroupSearchText(currentProjectGroupName);
+    } else {
+      setNonAdminProjectGroupId(null);
+      setProjectGroupSearchText("");
+    }
+
     refreshData();
   };
 
@@ -178,9 +227,13 @@ const MyDatasets = () => {
     { value: "Pre-Release", label: "Pre-Release" },
   ];
 
-  const includeMyGroupsOptions = [
-    { value: false, label: "All" },
-    { value: true, label: "My Project Groups" }
+  const datasetScopeOptions = [
+    { value: ALL_DATASETS_SCOPE, label: "All" },
+    {
+      value: CURRENT_PROJECT_GROUP_SCOPE,
+      label: "Current Project Group",
+    },
+    { value: MY_PROJECT_GROUPS_SCOPE, label: "My Project Groups" },
   ];
 
   const onSuccess = () => {
@@ -221,8 +274,10 @@ const MyDatasets = () => {
     useToggleDataviewer({ onSuccess, onError });
   const { mutate: createInclinationJob, isLoading: isCreatingJob } =
     useCreateInclinationJob({ onSuccess, onError });
-  const { mutate: createQualityReportJob, isLoading: isCreatingQualityReportJob } =
-    useCreateQualityReportJob({ onSuccess, onError });
+  const {
+    mutate: createQualityReportJob,
+    isLoading: isCreatingQualityReportJob,
+  } = useCreateQualityReportJob({ onSuccess, onError });
 
   const handlePublishDataset = (dataset) => {
     // Check if valid_from and valid_to dates are present
@@ -258,7 +313,7 @@ const MyDatasets = () => {
       // console.log("Quality report to be added for dataset: ", selectedDataset.tdei_dataset_id);
       createQualityReportJob(selectedDataset.tdei_dataset_id);
     }
-  }
+  };
 
   const handleCreateInclinationJob = () => {
     createInclinationJob(selectedDataset.tdei_dataset_id);
@@ -393,9 +448,11 @@ const MyDatasets = () => {
       modaltype: "error",
     },
     dataviewer: {
-      message: `Are you sure you want to ${selectedDataset?.data_viewer_allowed ? "disable" : "enable"
-        } the dataviewer status for dataset ${selectedDataset?.metadata?.dataset_detail?.name
-        }?`,
+      message: `Are you sure you want to ${
+        selectedDataset?.data_viewer_allowed ? "disable" : "enable"
+      } the dataviewer status for dataset ${
+        selectedDataset?.metadata?.dataset_detail?.name
+      }?`,
       content: "",
       handler: handleDataviewerChange,
       btnlabel: selectedDataset?.data_viewer_allowed ? "Disable" : "Enable",
@@ -408,7 +465,7 @@ const MyDatasets = () => {
       handler: handleCreateQualityReportJob,
       btnlabel: "Generate Quality Report",
       modaltype: "qualityReport",
-    }
+    },
   };
 
   const currentModalConfig = modalConfig[eventKey];
@@ -450,7 +507,8 @@ const MyDatasets = () => {
       case "qualityReport":
         return operationResult === "success"
           ? "Success! Quality report job has been initiated."
-          : customErrorMessage ?? "Error! Failed to initiate quality report job.";
+          : customErrorMessage ??
+              "Error! Failed to initiate quality report job.";
       default:
         return "";
     }
@@ -498,7 +556,9 @@ const MyDatasets = () => {
               </div>
               <div className={style.primaryFilterBlock}>
                 <div className={style.labelWithClear}>
-                  <Form.Label htmlFor="dataset-id-search-primary">Dataset ID</Form.Label>
+                  <Form.Label htmlFor="dataset-id-search-primary">
+                    Dataset ID
+                  </Form.Label>
                   <button
                     type="button"
                     className={style.clearButton}
@@ -524,15 +584,19 @@ const MyDatasets = () => {
               </div>
               {!isAdmin && (
                 <div className={style.primaryFilterBlockScope}>
-                  <Form.Label htmlFor="include-my-groups-filter">Dataset Scope</Form.Label>
+                  <Form.Label htmlFor="include-my-groups-filter">
+                    Dataset Scope
+                  </Form.Label>
                   <Select
                     className={style.datasetScopeSelect}
                     classNamePrefix="datasetScopeSelect"
                     inputId="include-my-groups-filter"
                     isSearchable={false}
-                    value={includeMyGroupsOptions.find((option) => option.value === includeMyGroups)}
-                    onChange={handleIncludeMyGroupsChange}
-                    options={includeMyGroupsOptions}
+                    value={datasetScopeOptions.find(
+                      (option) => option.value === datasetScope
+                    )}
+                    onChange={handleDatasetScopeChange}
+                    options={datasetScopeOptions}
                     components={{ IndicatorSeparator: () => null }}
                     aria-label="Filter by dataset scope"
                   />
@@ -585,7 +649,9 @@ const MyDatasets = () => {
                 <Col md={4} className={style.datasetFilterBlock}>
                   <Form.Group>
                     <div className={style.labelWithClear}>
-                      <Form.Label htmlFor="projectGroup-search">Project Group</Form.Label>
+                      <Form.Label htmlFor="projectGroup-search">
+                        Project Group
+                      </Form.Label>
                       <button
                         type="button"
                         className={style.clearButton}
@@ -615,6 +681,7 @@ const MyDatasets = () => {
                         type="button"
                         className={style.clearButton}
                         onClick={handleClearFilterProjectGroup}
+                        disabled={isCurrentProjectGroupScope}
                         aria-label="Clear project group filter"
                       >
                         Clear
@@ -624,6 +691,17 @@ const MyDatasets = () => {
                       searchText={projectGroupSearchText}
                       setSearchText={setProjectGroupSearchText}
                       onSelectProjectGroup={handleProjectGroupSelect}
+                      defaultProjectGroupId={
+                        isCurrentProjectGroupScope
+                          ? currentProjectGroupId
+                          : undefined
+                      }
+                      defaultProjectGroupName={
+                        isCurrentProjectGroupScope
+                          ? currentProjectGroupName
+                          : undefined
+                      }
+                      disabled={isCurrentProjectGroupScope}
                     />
                   </Form.Group>
                 </Col>

--- a/tdei-ui/src/routes/Datasets/MyDatasets.js
+++ b/tdei-ui/src/routes/Datasets/MyDatasets.js
@@ -601,8 +601,6 @@ const MyDatasets = () => {
                       searchText={projectGroupSearchText}
                       setSearchText={setProjectGroupSearchText}
                       onSelectProjectGroup={handleProjectGroupSelect}
-                      defaultProjectGroupId={selectedProjectGroup?.tdei_project_group_id}
-                      defaultProjectGroupName={selectedProjectGroup?.name}
                     />
                   </Form.Group>
                 </Col>

--- a/tdei-ui/src/services/apiServices.js
+++ b/tdei-ui/src/services/apiServices.js
@@ -601,7 +601,8 @@ export async function getDatasets(
   if (isAdmin && selectedProjectGroupId) {
     params.tdei_project_group_id = selectedProjectGroupId;
   } else if (!isAdmin) {
-    params.tdei_project_group_id = tdei_project_group_id;
+    // Use the filter override if set, otherwise fall back to the Redux selected project group
+    params.tdei_project_group_id = selectedProjectGroupId || tdei_project_group_id;
   }
 
   const res = await axios({

--- a/tdei-ui/src/services/apiServices.js
+++ b/tdei-ui/src/services/apiServices.js
@@ -600,9 +600,8 @@ export async function getDatasets(
   //Project ID if the user is admin
   if (isAdmin && selectedProjectGroupId) {
     params.tdei_project_group_id = selectedProjectGroupId;
-  } else if (!isAdmin) {
-    // Use the filter override if set, otherwise fall back to the Redux selected project group
-    params.tdei_project_group_id = selectedProjectGroupId || tdei_project_group_id;
+  } else if (!isAdmin && selectedProjectGroupId) {
+    params.tdei_project_group_id = selectedProjectGroupId;
   }
 
   const res = await axios({

--- a/tdei-ui/src/services/apiServices.js
+++ b/tdei-ui/src/services/apiServices.js
@@ -559,7 +559,7 @@ export async function getDatasets(
   validTo,
   tdei_service_id,
   selectedProjectGroupId,
-  tdei_project_group_id,
+  includeMyGroups,
   sortField = 'uploaded_timestamp',
   sortOrder = 'DESC'
 ) {
@@ -597,7 +597,11 @@ export async function getDatasets(
     params.tdei_service_id = tdei_service_id;
   }
 
-  //Project ID if the user is admin
+  if (!isAdmin && typeof includeMyGroups === "boolean") {
+    params.include_my_groups = includeMyGroups;
+  }
+
+  // Project ID if the user selected a local project group filter
   if (isAdmin && selectedProjectGroupId) {
     params.tdei_project_group_id = selectedProjectGroupId;
   } else if (!isAdmin && selectedProjectGroupId) {


### PR DESCRIPTION
## DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3682/

## Changes Implemented

- Added a new `Dataset Scope` filter for non-admin users in `My Datasets` with these options:
  - `All`
  - `Current Project Group`
  - `My Project Groups`
- Defaulted the dataset scope to `Current Project Group` using the Redux-selected project group.
- Updated dataset query behavior so non-admin requests now derive:
  - the effective project group id from the selected scope
  - the `includeMyGroups` flag based on the chosen scope
- When `Current Project Group` is selected:
  - the project group picker is prefilled with the currently selected project group
  - the picker is disabled/read-only
  - the `Clear` action for project group is disabled
- When switching away from `Current Project Group`:
  - the project group filter is cleared
  - the project group picker becomes editable again
- Updated `ProjectGroupRolesPicker` to support a `disabled` state, prevent focus/input interactions when disabled, and keep the default project group selection in sync.
- Included minor formatting and accessibility cleanup in the touched components.

## Testing Steps

1. Log in as a non-admin user and open `My Datasets`.
2. Verify `Dataset Scope` is visible and defaults to `Current Project Group`.
3. Confirm the `Project Group` field is prefilled with the currently selected project group and cannot be edited in that scope.
4. Confirm the `Clear` button for `Project Group` is disabled in `Current Project Group` scope.
5. Change scope to `All` and verify the project group filter clears and the picker becomes editable.
6. Change scope to `My Project Groups` and verify the picker remains editable and dataset results are restricted to the user’s project groups.
7. Switch back to `Current Project Group` and verify the current project group is restored automatically.
8. Log in as an admin user and verify existing dataset filtering behavior is unchanged and the non-admin scope control does not appear.

## Screenshots:
<img width="1470" height="956" alt="Screenshot 2026-06-26 at 5 07 01 PM" src="https://github.com/user-attachments/assets/727968a0-fafc-4cbb-9d8c-045ff5bde979" />
<img width="1470" height="956" alt="Screenshot 2026-06-26 at 5 07 06 PM" src="https://github.com/user-attachments/assets/fdc6e4a2-364e-4df9-a5d8-4383088e0ea4" />

## DevBoard task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3550

## Issue:
The "Manage Dataset" action menu was not keyboard-accessible for screen reader users. Items were only reachable via Shift+Tab, and pressing Enter/Space on the trigger would directly activate the first option ("Open in Workspaces") instead of opening the menu.

## Changes Implemented:
Replaced the React Bootstrap Dropdown with a WAI-ARIA compliant Menu Button component implementing the correct `role="menu"` / `role="menuitem"` pattern. Icons are marked `aria-hidden` so screen readers announce only the label. Styles use existing project theme variables.

## Keyboard Support
| Key | Behaviour |
|-----|-----------|
| `Enter` / `Space` on trigger | Opens menu, focuses first item |
| `↓` / `↑` | Moves focus between items |
| `Enter` / `Space` on item | Selects item, closes menu |
| `Escape` | Closes menu, returns focus to trigger |
| `Tab` | Closes menu |

## Areas Of Testing
1. Open the action menu with a mouse -> confirm all options appear and work as before.
2. Tab to the trigger, press **Enter** -> menu should open without triggering any action.
3. Use **Arrow keys** to navigate items, press **Enter** to select -> correct action should fire.
4. Press **Escape** -> menu should close and focus return to the trigger.
5. Test with VoiceOver (macOS) -> trigger should announce as **"menu button"** arrow keys should read each item label.
