### PR TITLE
Feature 4068-Dataset-Self-Merge job type download button addition

### DIFF
--- a/tdei-ui/src/components/JobListItem/JobListItem.js
+++ b/tdei-ui/src/components/JobListItem/JobListItem.js
@@ -238,6 +238,7 @@ const JobListItem = ({ jobItem }) => {
           jobItem.job_type === "Dataset-Sanitization" ||
           jobItem.job_type === "Dataset-Spatial-Join" ||
           jobItem.job_type === "Dataset-Union" ||
+          jobItem.job_type === "Dataset-Self-Merge" ||
           jobItem.job_type === "Quality-Metric" ||
           jobItem.job_type === "Confidence-Calculate"
         ) &&
@@ -245,6 +246,7 @@ const JobListItem = ({ jobItem }) => {
           (jobItem.download_url ||
             jobItem.job_type === "Dataset-Sanitization" ||
             jobItem.job_type === "Sanitization" ||
+            jobItem.job_type === "Dataset-Self-Merge" ||
             jobItem.job_type === "Quality-Metric" ||
             (jobItem.job_type === "Confidence-Calculate" && jobItem.response_props)) && (
             <button

--- a/tdei-ui/src/routes/Jobs/Jobs.js
+++ b/tdei-ui/src/routes/Jobs/Jobs.js
@@ -48,6 +48,7 @@ const Jobs = () => {
         { value: 'Dataset-Reformat', label: 'Dataset Reformat' },
         { value: 'Dataset-Road-Tag', label: 'Dataset Road Tag' },
         { value: 'Dataset-Sanitization', label: 'Dataset Sanitization' },
+        { value: 'Dataset-Self-Merge', label: 'Dataset Self Merge' },
         { value: 'Dataset-Spatial-Join', label: 'Dataset Spatial Join' },
         { value: 'Dataset-Union', label: 'Dataset Union' },
         { value: 'Dataset-Upload', label: 'Dataset Upload' },


### PR DESCRIPTION
Register the new 'Dataset-Self-Merge' job type and enable its UI handling. Adds the option to the job type list in Jobs.js and includes 'Dataset-Self-Merge' in JobListItem.js conditionals so it is treated like other dataset job types (e.g., shows download/button when applicable).

<img width="1469" height="880" alt="Screenshot 2026-07-23 at 3 40 57 PM" src="https://github.com/user-attachments/assets/49d777bb-0dbf-4339-989a-1c74d18197cd" />
