### PR TITLE
Dev to Stage

### DIFF
--- a/tdei-ui/src/assets/api_spec.json
+++ b/tdei-ui/src/assets/api_spec.json
@@ -669,6 +669,15 @@
                         }
                     },
                     {
+                        "name": "include_my_groups",
+                        "in": "query",
+                        "description": "<strong>Include my Group:</strong> When true, the API returns datasets only from project groups the authenticated user belongs to.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
                         "name": "page_no",
                         "in": "query",
                         "description": "<strong>page_no:</strong> Integer, defaults to 1. Filters datasets by retrieving results in pages.",
@@ -2361,6 +2370,81 @@
                     },
                     "404": {
                         "description": "Dataset not found for either tdei_dataset_id_one or tdei_dataset_id_two."
+                    },
+                    "500": {
+                        "description": "An Internal server error occured."
+                    }
+                },
+                "security": [
+                    {
+                        "ApiKey": []
+                    },
+                    {
+                        "AuthorizationToken": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/osw/self-merge": {
+            "post": {
+                "tags": [
+                    "OSW"
+                ],
+                "summary": "Performs a self-merge of entities within a single OSW dataset.",
+                "description": "This function merges spatial entities within one dataset by unifying nodes, edges, and polygons into consolidated geometries which are within the specified proximity. Entities that are within the specified proximity are treated as equivalent and merged. The function outputs a single cohesive dataset.The response includes a `job_id` for tracking the request.To check the request status, refer to the location header in the response, which provides the URL for the status API endpoint.",
+                "operationId": "osw-self-merge",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "tdei_dataset_id": {
+                                        "type": "string",
+                                        "example": "b688519d-ea00-4daa-a23f-0aff2ca138d2",
+                                        "description": "Dataset id to self-merge"
+                                    },
+                                    "proximity": {
+                                        "type": "number",
+                                        "example": "1.0",
+                                        "description": "Proximity value to identify equivalent entities in meters. Default value is 0.5 meters."
+                                    }
+                                },
+                                "required": [
+                                    "tdei_dataset_id"
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "The request has been accepted for processing. It returns a `job_id`, a unique identifier for the request, which can be used to track the status of the request. The endpoint to check the status is provided in the location header of the response.",
+                        "content": {
+                            "application/text": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "description": "Location api to find the status of request processing"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "The request body is empty."
+                    },
+                    "401": {
+                        "description": "Unauthenticated request. Check your access token."
+                    },
+                    "404": {
+                        "description": "Dataset not found for tdei_dataset_id."
                     },
                     "500": {
                         "description": "An Internal server error occured."

--- a/tdei-ui/src/components/JobListItem/JobListItem.js
+++ b/tdei-ui/src/components/JobListItem/JobListItem.js
@@ -238,6 +238,7 @@ const JobListItem = ({ jobItem }) => {
           jobItem.job_type === "Dataset-Sanitization" ||
           jobItem.job_type === "Dataset-Spatial-Join" ||
           jobItem.job_type === "Dataset-Union" ||
+          jobItem.job_type === "Dataset-Self-Merge" ||
           jobItem.job_type === "Quality-Metric" ||
           jobItem.job_type === "Confidence-Calculate"
         ) &&
@@ -245,6 +246,7 @@ const JobListItem = ({ jobItem }) => {
           (jobItem.download_url ||
             jobItem.job_type === "Dataset-Sanitization" ||
             jobItem.job_type === "Sanitization" ||
+            jobItem.job_type === "Dataset-Self-Merge" ||
             jobItem.job_type === "Quality-Metric" ||
             (jobItem.job_type === "Confidence-Calculate" && jobItem.response_props)) && (
             <button

--- a/tdei-ui/src/routes/Jobs/CreateJob.js
+++ b/tdei-ui/src/routes/Jobs/CreateJob.js
@@ -35,6 +35,7 @@ const jobTypeOptions = [
     { value: 'quality-metric-tag', label: 'Quality Metric Tag' },
     { value: 'spatial-join', label: 'Spatial Join' },
     { value: 'dataset-union', label: 'Dataset Union' },
+    { value: 'dataset-self-merge', label: 'Dataset Self Merge' },
     { value: 'quality-report', label: 'Quality Report' }
 ];
 
@@ -97,6 +98,10 @@ const formConfig = {
     "dataset-union": [
         { label: "First Dataset Id", type: "text", stateSetter: "setDatasetIdOne" },
         { label: "Second Dataset Id", type: "text", stateSetter: "setDatasetIdTwo" },
+        { label: "Proximity", type: "text", stateSetter: "setProximity" }
+    ],
+    "dataset-self-merge": [
+        { label: "Tdei Dataset Id", type: "text", stateSetter: "setTdeiDatasetId" },
         { label: "Proximity", type: "text", stateSetter: "setProximity" }
     ],
     "quality-report": [
@@ -235,6 +240,9 @@ const CreateJobService = () => {
         setTdeiDatasetId("");
         setSourceDatasetId("");
         setTargetDatasetId("");
+        setFirstDatasetId("");
+        setSecondDatasetId("");
+        setProximity("");
         setSpatialRequestBody(JSON.stringify(SPATIAL_JOIN, null, 2));
         setAlgorithmConfig({
             algorithms: [],
@@ -315,6 +323,7 @@ const CreateJobService = () => {
             "quality-metric-tag": "/api/v1/osw/quality-metric/tag/{tdei_dataset_id}",
             "spatial-join": "/api/v1/osw/spatial-join",
             "dataset-union": "/api/v1/osw/union",
+            "dataset-self-merge": "/api/v1/osw/self-merge",
             "quality-report": "/api/v1/osw/quality-report/{tdei_dataset_id}",
         };
 
@@ -389,6 +398,12 @@ const CreateJobService = () => {
         } else {
             return apiSpec.paths[path]?.post?.requestBody?.content["application/json"]?.schema?.properties?.proximity?.description || "";
         }
+    };
+
+    const getSelfMergeDescription = (label) => {
+        const path = getPathFromJobType("dataset-self-merge");
+        const property = label === "Tdei Dataset Id" ? "tdei_dataset_id" : "proximity";
+        return apiSpec.paths[path]?.post?.requestBody?.content["application/json"]?.schema?.properties?.[property]?.description || "";
     };
 
     // Retrieves descriptions for quality report generation related fields based on the label.
@@ -473,6 +488,11 @@ const CreateJobService = () => {
             setShowValidateToast(true);
             return;
         }
+        if (jobType.value === "dataset-self-merge" && !tdeiDatasetId) {
+            setValidateErrorMessage("Tdei Dataset Id is required for Dataset Self Merge");
+            setShowValidateToast(true);
+            return;
+        }
 
         // Determine the API path based on the job type
         let urlPath = "";
@@ -512,6 +532,9 @@ const CreateJobService = () => {
                 break;
             case "dataset-union":
                 urlPath = "osw/union";
+                break;
+            case "dataset-self-merge":
+                urlPath = "osw/self-merge";
                 break;
             case "quality-report":
                 urlPath = `osw/quality-report/${tdeiDatasetId}`;
@@ -577,6 +600,17 @@ const CreateJobService = () => {
             } else {
                 uploadData.push(firstDatasetId, secondDatasetId);
             }
+        } else if (jobType.value === "dataset-self-merge") {
+            if (proximity) {
+                const proximityFloat = parseFloat(proximity);
+                if (!isNaN(proximityFloat)) {
+                    uploadData.push(tdeiDatasetId, proximityFloat);
+                } else {
+                    uploadData.push(tdeiDatasetId);
+                }
+            } else {
+                uploadData.push(tdeiDatasetId);
+            }
         }
         setLoading(true);
         mutate(uploadData);
@@ -605,6 +639,8 @@ const CreateJobService = () => {
                     return getQualityMetricTagDescription(label);
                 case "dataset-union":
                     return getUnionDescription(label);
+                case "dataset-self-merge":
+                    return getSelfMergeDescription(label);
                 case "quality-report":
                     return getQualityReportDescription(label);
                 default:
@@ -654,7 +690,7 @@ const CreateJobService = () => {
                 <Form.Group key={index} controlId={field.label} className={style.formItem}>
                     <Form.Label>
                         {field.label}
-                        {!(jobType?.value === "dataset-union" && field.label === "Proximity") && (
+                        {!(["dataset-union", "dataset-self-merge"].includes(jobType?.value) && field.label === "Proximity") && (
                             <span style={{ color: 'red' }}> *</span>
                         )}
                     </Form.Label>

--- a/tdei-ui/src/routes/Jobs/Jobs.js
+++ b/tdei-ui/src/routes/Jobs/Jobs.js
@@ -48,6 +48,7 @@ const Jobs = () => {
         { value: 'Dataset-Reformat', label: 'Dataset Reformat' },
         { value: 'Dataset-Road-Tag', label: 'Dataset Road Tag' },
         { value: 'Dataset-Sanitization', label: 'Dataset Sanitization' },
+        { value: 'Dataset-Self-Merge', label: 'Dataset Self Merge' },
         { value: 'Dataset-Spatial-Join', label: 'Dataset Spatial Join' },
         { value: 'Dataset-Union', label: 'Dataset Union' },
         { value: 'Dataset-Upload', label: 'Dataset Upload' },

--- a/tdei-ui/src/services/apiServices.js
+++ b/tdei-ui/src/services/apiServices.js
@@ -436,6 +436,17 @@ export async function postCreateJob(data) {
         };
         response = await axios.post(url, unionRequestBody, { headers });
         return response.data;
+      case "osw/self-merge":
+        const selfMergeRequestBody = {
+          tdei_dataset_id: data[2],
+          proximity: data[3],
+        };
+        url = baseUrl;
+        headers = {
+          'Content-Type': 'application/json',
+        };
+        response = await axios.post(url, selfMergeRequestBody, { headers });
+        return response.data;
       default:
         formData.append("dataset", data[1]);
         url = baseUrl;


### PR DESCRIPTION
# DevBoard Task
https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/4068/

## Changes Implemented

- Added a new **Dataset Self Merge** job option.
- Added fields for:
  - **TDEI Dataset ID** — required.
  - **Proximity** — optional; defaults to `0.5` meters on the API side.
- Added required-field validation for the dataset ID.
- Added descriptions sourced from the API specification.
- Integrated the `/api/v1/osw/self-merge` endpoint.
- Proximity is converted to a number before submission.
- Added form-state cleanup when switching job types.

## Impacted Areas for Testing

- Verify **Dataset Self Merge** appears in the Job Type dropdown.
- Verify selecting it displays the Dataset ID and Proximity fields.
- Verify submission is blocked when Dataset ID is empty.
- Verify the job can be submitted without Proximity.
- Verify decimal Proximity values are sent as JSON numbers.
- Verify the request payload follows:

  ```json
  {
    "tdei_dataset_id": "<dataset-id>",
    "proximity": 0.5
  }
  ```

- Verify success and API error notifications.
- Verify switching job types clears previously entered values.
- Regression-test **Dataset Union** and other job creation flows.

## Screenshots
<img width="1470" height="836" alt="Screenshot 2026-07-23 at 12 02 21 PM" src="https://github.com/user-attachments/assets/dceda5f4-c82c-4c83-bf54-0a59c718fa20" />
